### PR TITLE
Qt-free chess core, CMake build and CI (1/6)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,23 @@
+# WebKit style: 4-space indent, opening brace on its own line for functions and
+# on the same line for control statements. Chosen because it is what the new
+# core was written in, so adopting it costs no reformatting churn.
+---
+Language: Cpp
+BasedOnStyle: WebKit
+ColumnLimit: 110
+PointerAlignment: Left
+ReferenceAlignment: Left
+AllowShortFunctionsOnASingleLine: Inline
+AlwaysBreakTemplateDeclarations: Yes
+SortIncludes: CaseSensitive
+IncludeBlocks: Preserve
+SpaceAfterTemplateKeyword: false
+FixNamespaceComments: true
+
+# Overrides of WebKit defaults that do not suit this code base.
+# Braced initialisers are written Piece{} rather than Piece { }, and namespace
+# bodies are not indented -- otherwise every file in an anonymous namespace
+# would carry a level of indentation that means nothing.
+Cpp11BracedListStyle: true
+SpaceBeforeCpp11BracedList: false
+NamespaceIndentation: None

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,31 @@
+# Run over src/core only. The checks are chosen to catch the specific failure
+# modes the 2012 code shipped with: raw owning pointers, implicit narrowing,
+# uninitialised members, and identifiers that shadow standard library names.
+---
+Checks: >
+  -*,
+  bugprone-*,
+  cppcoreguidelines-init-variables,
+  cppcoreguidelines-prefer-member-initializer,
+  cppcoreguidelines-pro-type-member-init,
+  cppcoreguidelines-slicing,
+  misc-*,
+  modernize-*,
+  performance-*,
+  readability-*,
+  -bugprone-easily-swappable-parameters,
+  -misc-non-private-member-variables-in-classes,
+  -modernize-use-trailing-return-type,
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -misc-include-cleaner,
+  -modernize-use-designated-initializers
+
+# misc-include-cleaner is an include-what-you-use pass. It wants every .cpp to
+# re-include what its own header already provides, which is churn without
+# safety here. modernize-use-designated-initializers is off because Piece's two
+# members have distinct types, so a positional swap will not compile anyway.
+
+WarningsAsErrors: '*'
+HeaderFilterRegex: 'src/core/include/chess/.*\.hpp$'
+FormatStyle: file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,124 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# A new push to the same branch supersedes the run in flight.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Pinned so a new upstream release cannot turn a green branch red overnight,
+  # and so contributors can reproduce the lint result exactly:
+  #   pip install clang-format==22.1.8 clang-tidy==22.1.8
+  LLVM_TOOLS_VERSION: 22.1.8
+
+jobs:
+  lint:
+    name: Lint (format + tidy)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
+
+      - name: Install pinned LLVM tools
+        run: pip install "clang-format==${LLVM_TOOLS_VERSION}" "clang-tidy==${LLVM_TOOLS_VERSION}"
+
+      - name: Check formatting
+        run: |
+          clang-format --version
+          clang-format --dry-run --Werror \
+            src/core/include/chess/*.hpp src/core/src/*.cpp tests/*.cpp
+
+      # clang-tidy needs a compilation database, so configure first. Building is
+      # not required -- the CI preset exports compile_commands.json at configure
+      # time. Configure with clang rather than the default gcc so the recorded
+      # flags are ones clang-tidy's own driver understands.
+      - name: Configure for the compilation database
+        env:
+          CC: clang
+          CXX: clang++
+        run: cmake --preset ci
+
+      - name: Run clang-tidy over the core
+        run: |
+          clang-tidy --version
+          clang-tidy -p build/ci --quiet src/core/src/*.cpp
+
+  build-test:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            os: ubuntu-24.04
+          - name: Windows
+            os: windows-latest
+          - name: macOS
+            os: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
+
+      # The Ninja generator needs the MSVC environment on the PATH; the action
+      # exports it for every later step in the job.
+      - name: Set up MSVC
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      - name: Configure
+        run: cmake --preset ci
+
+      # The ci preset sets CINES_WERROR, so any new warning fails here.
+      - name: Build
+        run: cmake --build --preset ci
+
+      - name: Test
+        run: ctest --preset ci
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
+
+      - name: Install gcovr
+        run: pipx install gcovr
+
+      - name: Build and test with coverage
+        run: |
+          cmake --preset ci-coverage
+          cmake --build --preset ci-coverage
+          ctest --preset ci-coverage
+
+      # Only the rules library is measured. Test code and the fetched
+      # googletest sources would otherwise dominate the number and hide it.
+      - name: Generate report
+        run: |
+          gcovr --root . --filter 'src/core/' \
+            --exclude-unreachable-branches \
+            --print-summary --xml coverage.xml
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,30 @@ jobs:
       - name: Test
         run: ctest --preset ci
 
+  # Square::None is -1, and it is a legitimate return from makeSquare,
+  # Board::kingSquare and Position::enPassantTarget. Subscripting a 64-entry
+  # array with it reads far outside the array, and an assert only catches that
+  # in a build with assertions on. This job is what makes the whole class of
+  # mistake fail loudly rather than quietly.
+  sanitizers:
+    name: Sanitizers (address + UB)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
+
+      - name: Build and test with sanitizers
+        env:
+          CC: clang
+          CXX: clang++
+          ASAN_OPTIONS: detect_leaks=1:abort_on_error=1
+          UBSAN_OPTIONS: print_stacktrace=1
+        run: |
+          cmake --preset ci-asan
+          cmake --build --preset ci-asan
+          ctest --preset ci-asan
+
   coverage:
     name: Coverage
     runs-on: ubuntu-24.04
@@ -99,7 +123,7 @@ jobs:
       - uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
 
       - name: Install gcovr
-        run: pipx install gcovr
+        run: pipx install "gcovr==8.6"
 
       - name: Build and test with coverage
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,21 @@
-# Ignore temporary files generated
-build/*
+# Build output
+build/
 Makefile
+
+# CMake
+CMakeUserPresets.json
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+compile_commands.json
+
+# Tooling caches
+.cache/
+
+# Editors
+.vscode/
+.idea/
+*.user
+
+# macOS
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.21)
+
+# The version is normally injected by CI from the git tag (-DCINES_VERSION=1.2.3).
+# The fallback keeps local configure working on a fresh clone.
+if(NOT DEFINED CINES_VERSION)
+  set(CINES_VERSION "0.0.0")
+endif()
+
+project(Cines
+  VERSION ${CINES_VERSION}
+  DESCRIPTION "CINES - a two player chess game"
+  HOMEPAGE_URL "https://github.com/sanketsudake/CHESS-in-Qt"
+  LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(APPLE AND NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0" CACHE STRING "Minimum macOS version")
+endif()
+
+option(CINES_BUILD_TESTS "Build the test suite" ON)
+option(CINES_SLOW_TESTS "Include the deep perft levels (minutes, not seconds)" OFF)
+option(CINES_WERROR "Treat compiler warnings as errors" OFF)
+
+# Applied to every target we own. Third-party code pulled in by FetchContent
+# does not link this, so its warnings stay out of our build log.
+add_library(cines_warnings INTERFACE)
+if(MSVC)
+  target_compile_options(cines_warnings INTERFACE /W4 $<$<BOOL:${CINES_WERROR}>:/WX>)
+else()
+  target_compile_options(cines_warnings INTERFACE
+    -Wall -Wextra -Wpedantic -Wshadow -Wconversion
+    $<$<BOOL:${CINES_WERROR}>:-Werror>)
+endif()
+
+add_subdirectory(src/core)
+
+if(CINES_BUILD_TESTS)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.21)
+# 3.25 is required for FetchContent_Declare(... SYSTEM) in tests/CMakeLists.txt,
+# which is what keeps googletest's warnings out of our build log.
+cmake_minimum_required(VERSION 3.25)
 
 # The version is normally injected by CI from the git tag (-DCINES_VERSION=1.2.3).
 # The fallback keeps local configure working on a fresh clone.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 3,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 21,
+    "minor": 25,
     "patch": 0
   },
   "configurePresets": [
@@ -44,6 +44,17 @@
       }
     },
     {
+      "name": "ci-asan",
+      "inherits": "base",
+      "displayName": "CI sanitizers (address + undefined behaviour)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CINES_BUILD_TESTS": "ON",
+        "CMAKE_CXX_FLAGS": "-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined"
+      }
+    },
+    {
       "name": "ci-coverage",
       "inherits": "base",
       "displayName": "CI coverage (Debug + gcov instrumentation)",
@@ -59,6 +70,7 @@
     { "name": "dev", "configurePreset": "dev" },
     { "name": "release", "configurePreset": "release" },
     { "name": "ci", "configurePreset": "ci" },
+    { "name": "ci-asan", "configurePreset": "ci-asan" },
     { "name": "ci-coverage", "configurePreset": "ci-coverage" }
   ],
   "testPresets": [
@@ -74,9 +86,16 @@
       "execution": { "noTestsAction": "error" }
     },
     {
+      "name": "ci-asan",
+      "configurePreset": "ci-asan",
+      "output": { "outputOnFailure": true },
+      "execution": { "noTestsAction": "error" }
+    },
+    {
       "name": "ci-coverage",
       "configurePreset": "ci-coverage",
-      "output": { "outputOnFailure": true }
+      "output": { "outputOnFailure": true },
+      "execution": { "noTestsAction": "error" }
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,82 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "dev",
+      "inherits": "base",
+      "displayName": "Development (Debug, warnings not fatal)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CINES_BUILD_TESTS": "ON"
+      }
+    },
+    {
+      "name": "release",
+      "inherits": "base",
+      "displayName": "Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CINES_BUILD_TESTS": "OFF"
+      }
+    },
+    {
+      "name": "ci",
+      "inherits": "base",
+      "displayName": "CI (RelWithDebInfo, warnings are errors)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CINES_BUILD_TESTS": "ON",
+        "CINES_WERROR": "ON"
+      }
+    },
+    {
+      "name": "ci-coverage",
+      "inherits": "base",
+      "displayName": "CI coverage (Debug + gcov instrumentation)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CINES_BUILD_TESTS": "ON",
+        "CMAKE_CXX_FLAGS": "--coverage -fprofile-update=atomic",
+        "CMAKE_EXE_LINKER_FLAGS": "--coverage"
+      }
+    }
+  ],
+  "buildPresets": [
+    { "name": "dev", "configurePreset": "dev" },
+    { "name": "release", "configurePreset": "release" },
+    { "name": "ci", "configurePreset": "ci" },
+    { "name": "ci-coverage", "configurePreset": "ci-coverage" }
+  ],
+  "testPresets": [
+    {
+      "name": "dev",
+      "configurePreset": "dev",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "ci",
+      "configurePreset": "ci",
+      "output": { "outputOnFailure": true },
+      "execution": { "noTestsAction": "error" }
+    },
+    {
+      "name": "ci-coverage",
+      "configurePreset": "ci-coverage",
+      "output": { "outputOnFailure": true }
+    }
+  ]
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(chesscore STATIC
+  src/Types.cpp
+  src/Board.cpp
+  src/Position.cpp
+  src/Move.cpp
+  src/Fen.cpp
+)
+
+add_library(cines::core ALIAS chesscore)
+
+target_include_directories(chesscore PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+
+target_link_libraries(chesscore PRIVATE cines_warnings)
+
+# The whole point of this library is that the rules are testable without a GUI.
+# Nothing here may include a Qt header.
+set_target_properties(chesscore PROPERTIES
+  POSITION_INDEPENDENT_CODE ON)

--- a/src/core/include/chess/Board.hpp
+++ b/src/core/include/chess/Board.hpp
@@ -3,6 +3,7 @@
 #include "chess/Types.hpp"
 
 #include <array>
+#include <cassert>
 
 namespace chess {
 
@@ -15,9 +16,22 @@ class Board {
 public:
     Board() = default;
 
-    [[nodiscard]] Piece pieceAt(Square s) const { return squares_[static_cast<std::size_t>(index(s))]; }
+    // Square::None indexes at -1, which as an unsigned subscript reads or
+    // writes far outside the array. Several things legitimately produce
+    // Square::None -- makeSquare off the edge of the board, kingSquare with no
+    // king, an absent en passant target -- so callers must reject it before
+    // asking about a square, and this asserts that they did.
+    [[nodiscard]] Piece pieceAt(Square s) const
+    {
+        assert(isValid(s));
+        return squares_[static_cast<std::size_t>(index(s))];
+    }
 
-    void setPiece(Square s, Piece piece) { squares_[static_cast<std::size_t>(index(s))] = piece; }
+    void setPiece(Square s, Piece piece)
+    {
+        assert(isValid(s));
+        squares_[static_cast<std::size_t>(index(s))] = piece;
+    }
 
     void clearSquare(Square s) { setPiece(s, Piece{}); }
 

--- a/src/core/include/chess/Board.hpp
+++ b/src/core/include/chess/Board.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "chess/Types.hpp"
+
+#include <array>
+
+namespace chess {
+
+// Piece placement, and nothing else.
+//
+// Side to move, castling rights and the en passant target live in Position.
+// Keeping them apart is what lets move generation reason about "what is on
+// this square" without carrying the rest of the game state around.
+class Board {
+public:
+    Board() = default;
+
+    [[nodiscard]] Piece pieceAt(Square s) const { return squares_[static_cast<std::size_t>(index(s))]; }
+
+    void setPiece(Square s, Piece piece) { squares_[static_cast<std::size_t>(index(s))] = piece; }
+
+    void clearSquare(Square s) { setPiece(s, Piece{}); }
+
+    [[nodiscard]] bool isEmpty(Square s) const { return pieceAt(s).isEmpty(); }
+
+    // True when the square holds a piece of the given colour. An empty square
+    // is neither colour, which is the check move generation actually wants.
+    [[nodiscard]] bool hasPieceOf(Square s, Color color) const
+    {
+        const Piece piece = pieceAt(s);
+        return !piece.isEmpty() && piece.color == color;
+    }
+
+    void clear() { squares_.fill(Piece{}); }
+
+    // Square::None when that side has no king. A legal position always has
+    // one, but FEN can describe positions that do not, and tests use them.
+    [[nodiscard]] Square kingSquare(Color color) const;
+
+    [[nodiscard]] static Board startingPosition();
+
+    friend bool operator==(const Board& a, const Board& b) { return a.squares_ == b.squares_; }
+
+private:
+    std::array<Piece, kSquareCount> squares_{};
+};
+
+} // namespace chess

--- a/src/core/include/chess/Fen.hpp
+++ b/src/core/include/chess/Fen.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "chess/Position.hpp"
+
+#include <string>
+#include <string_view>
+#include <variant>
+
+// Forsyth-Edwards Notation: the standard one-line text form of a position.
+// This is how tests state their starting positions, how the user interface
+// offers "copy position", and how the perft suite is fed.
+namespace chess::fen {
+
+inline constexpr std::string_view kStartingPosition
+    = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+struct ParseError {
+    std::string message;
+};
+
+using ParseResult = std::variant<Position, ParseError>;
+
+// Parses a full six-field FEN record. The halfmove clock and fullmove number
+// are optional, as many published test positions omit them; they default to
+// 0 and 1.
+//
+// Rejects, rather than silently repairing: the wrong number of ranks, a rank
+// that does not describe eight squares, an unknown piece letter, a side-to-move
+// field other than "w" or "b", a malformed castling or en passant field, and
+// negative or non-numeric counters.
+[[nodiscard]] ParseResult parse(std::string_view text);
+
+// Serialises a position back to a six-field record. parse(serialise(p)) is p
+// for every position parse accepts.
+[[nodiscard]] std::string serialise(const Position& position);
+
+} // namespace chess::fen

--- a/src/core/include/chess/Move.hpp
+++ b/src/core/include/chess/Move.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "chess/Types.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace chess {
+
+// What kind of move this is, beyond "piece goes from A to B".
+//
+// The generator sets this so that applying a move needs no re-derivation:
+// an en passant capture removes a pawn that is not on the destination square,
+// and a castle moves two pieces. Deciding that later, from the board alone,
+// is exactly the sort of duplicated reasoning the 2012 code got wrong.
+enum class MoveKind : std::uint8_t {
+    Quiet,
+    Capture,
+    DoublePawnPush,
+    EnPassant,
+    CastleKingSide,
+    CastleQueenSide,
+};
+
+struct Move {
+    Square from = Square::None;
+    Square to = Square::None;
+
+    // PieceType::None unless the move promotes. Only Knight, Bishop, Rook and
+    // Queen are ever stored here.
+    PieceType promotion = PieceType::None;
+
+    MoveKind kind = MoveKind::Quiet;
+
+    [[nodiscard]] constexpr bool isValid() const { return chess::isValid(from) && chess::isValid(to); }
+
+    [[nodiscard]] constexpr bool isPromotion() const { return promotion != PieceType::None; }
+
+    [[nodiscard]] constexpr bool isCastle() const
+    {
+        return kind == MoveKind::CastleKingSide || kind == MoveKind::CastleQueenSide;
+    }
+
+    [[nodiscard]] constexpr bool isCapture() const
+    {
+        return kind == MoveKind::Capture || kind == MoveKind::EnPassant;
+    }
+
+    // Long algebraic notation as used by UCI: "e2e4", "e7e8q", "e1g1" for a
+    // king-side castle. Promotion letters are lower case.
+    [[nodiscard]] std::string toUci() const;
+
+    // Parses the string form above. This produces from, to and promotion only
+    // -- kind cannot be known without a position, so it stays Quiet. Use this
+    // to look a move up in a generated move list rather than to apply it.
+    [[nodiscard]] static std::optional<Move> fromUci(std::string_view text);
+
+    // Two moves are the same move when they come from and go to the same
+    // squares and promote to the same piece. Kind is derived from those in a
+    // given position, so it is not part of identity.
+    friend constexpr bool operator==(const Move& a, const Move& b)
+    {
+        return a.from == b.from && a.to == b.to && a.promotion == b.promotion;
+    }
+};
+
+} // namespace chess

--- a/src/core/include/chess/Position.hpp
+++ b/src/core/include/chess/Position.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "chess/Board.hpp"
+#include "chess/Types.hpp"
+
+#include <cstdint>
+
+namespace chess {
+
+// Which castles are still available, as a bitmask. A right is lost when the
+// king moves, when the rook on that side moves, or when that rook is captured.
+// It is never regained, so this only ever shrinks over a game.
+class CastlingRights {
+public:
+    enum Flag : std::uint8_t {
+        None = 0,
+        WhiteKingSide = 1U << 0U,
+        WhiteQueenSide = 1U << 1U,
+        BlackKingSide = 1U << 2U,
+        BlackQueenSide = 1U << 3U,
+        All = WhiteKingSide | WhiteQueenSide | BlackKingSide | BlackQueenSide,
+    };
+
+    constexpr CastlingRights() = default;
+    constexpr explicit CastlingRights(std::uint8_t bits)
+        : bits_(bits)
+    {
+    }
+
+    [[nodiscard]] constexpr bool has(Flag flag) const
+    {
+        return (bits_ & static_cast<std::uint8_t>(flag)) != 0U;
+    }
+    constexpr void add(Flag flag) { bits_ |= static_cast<std::uint8_t>(flag); }
+    constexpr void remove(Flag flag)
+    {
+        bits_ = static_cast<std::uint8_t>(bits_ & ~static_cast<std::uint8_t>(flag));
+    }
+    [[nodiscard]] constexpr std::uint8_t bits() const { return bits_; }
+
+    [[nodiscard]] static constexpr Flag kingSideFor(Color c)
+    {
+        return c == Color::White ? WhiteKingSide : BlackKingSide;
+    }
+
+    [[nodiscard]] static constexpr Flag queenSideFor(Color c)
+    {
+        return c == Color::White ? WhiteQueenSide : BlackQueenSide;
+    }
+
+    friend constexpr bool operator==(CastlingRights a, CastlingRights b) { return a.bits_ == b.bits_; }
+
+private:
+    std::uint8_t bits_ = None;
+};
+
+// A complete chess position: everything needed to decide what moves are legal
+// and whether the game has ended. Two Positions comparing equal are the same
+// position for every rule purpose except the move counters.
+struct Position {
+    Board board;
+    Color sideToMove = Color::White;
+    CastlingRights castling;
+
+    // The square a pawn just skipped over, which an enemy pawn may capture
+    // onto. Square::None when the previous move was not a double pawn push.
+    // Set unconditionally after a double push, matching FEN as written by
+    // most tools, so a position compares unequal to one where no push happened.
+    Square enPassantTarget = Square::None;
+
+    // Plies since the last capture or pawn move. The game is drawn at 100.
+    int halfmoveClock = 0;
+
+    // Starts at 1 and increments after Black moves.
+    int fullmoveNumber = 1;
+
+    [[nodiscard]] static Position starting();
+
+    // Equality for threefold repetition: placement, side to move, castling
+    // rights and en passant target, deliberately excluding the two counters.
+    // Two positions that differ only in move number are the same position.
+    [[nodiscard]] bool sameGameState(const Position& other) const;
+
+    friend bool operator==(const Position& a, const Position& b);
+};
+
+} // namespace chess

--- a/src/core/include/chess/Types.hpp
+++ b/src/core/include/chess/Types.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+// Core value types for the chess rules.
+//
+// Nothing in namespace chess may include a Qt header. The rules are a plain
+// C++ library so that they can be unit tested without a display, and so that
+// the user interface can be replaced without touching them.
+namespace chess {
+
+enum class Color : std::uint8_t { White, Black };
+
+[[nodiscard]] constexpr Color opposite(Color c) noexcept
+{
+    return c == Color::White ? Color::Black : Color::White;
+}
+
+enum class PieceType : std::uint8_t { None, Pawn, Knight, Bishop, Rook, Queen, King };
+
+// A piece on a square. A default-constructed Piece means "empty square"; the
+// colour is meaningless in that case and is never read.
+struct Piece {
+    PieceType type = PieceType::None;
+    Color color = Color::White;
+
+    [[nodiscard]] constexpr bool isEmpty() const noexcept { return type == PieceType::None; }
+
+    friend constexpr bool operator==(const Piece& a, const Piece& b) noexcept
+    {
+        if (a.type != b.type) {
+            return false;
+        }
+        return a.type == PieceType::None || a.color == b.color;
+    }
+};
+
+enum class File : std::int8_t { A, B, C, D, E, F, G, H };
+enum class Rank : std::int8_t { R1, R2, R3, R4, R5, R6, R7, R8 };
+
+// Squares are indexed A1=0, B1=1 ... H1=7, A2=8 ... H8=63, that is
+// index = rank * 8 + file. Rank 1 is White's back rank.
+enum class Square : std::int8_t {
+    // clang-format off
+    None = -1,
+    A1, B1, C1, D1, E1, F1, G1, H1,
+    A2, B2, C2, D2, E2, F2, G2, H2,
+    A3, B3, C3, D3, E3, F3, G3, H3,
+    A4, B4, C4, D4, E4, F4, G4, H4,
+    A5, B5, C5, D5, E5, F5, G5, H5,
+    A6, B6, C6, D6, E6, F6, G6, H6,
+    A7, B7, C7, D7, E7, F7, G7, H7,
+    A8, B8, C8, D8, E8, F8, G8, H8,
+    // clang-format on
+};
+
+inline constexpr int kBoardSize = 8;
+inline constexpr int kSquareCount = 64;
+
+[[nodiscard]] constexpr bool isValid(Square s) noexcept
+{
+    return s != Square::None;
+}
+
+[[nodiscard]] constexpr int index(Square s) noexcept
+{
+    return static_cast<int>(s);
+}
+
+[[nodiscard]] constexpr File fileOf(Square s) noexcept
+{
+    return static_cast<File>(index(s) % kBoardSize);
+}
+
+[[nodiscard]] constexpr Rank rankOf(Square s) noexcept
+{
+    return static_cast<Rank>(index(s) / kBoardSize);
+}
+
+[[nodiscard]] constexpr Square makeSquare(File f, Rank r) noexcept
+{
+    return static_cast<Square>((static_cast<int>(r) * kBoardSize) + static_cast<int>(f));
+}
+
+// Builds a square from zero-based file and rank, returning Square::None when
+// either coordinate falls off the board. Move generation relies on this to
+// reject candidate destinations without duplicating bounds checks.
+[[nodiscard]] constexpr Square makeSquare(int file, int rank) noexcept
+{
+    if (file < 0 || file >= kBoardSize || rank < 0 || rank >= kBoardSize) {
+        return Square::None;
+    }
+    return static_cast<Square>((rank * kBoardSize) + file);
+}
+
+// The rank a pawn of this colour starts on, and the rank it promotes on.
+[[nodiscard]] constexpr Rank pawnStartRank(Color c) noexcept
+{
+    return c == Color::White ? Rank::R2 : Rank::R7;
+}
+
+[[nodiscard]] constexpr Rank promotionRank(Color c) noexcept
+{
+    return c == Color::White ? Rank::R8 : Rank::R1;
+}
+
+// The direction a pawn of this colour advances, in ranks.
+[[nodiscard]] constexpr int pawnPush(Color c) noexcept
+{
+    return c == Color::White ? 1 : -1;
+}
+
+// Algebraic name of a square, for example "e4". Square::None yields "-", which
+// is what FEN uses for an absent en passant target.
+[[nodiscard]] std::string toString(Square s);
+
+// Parses "a1" through "h8". Returns nullopt for anything else, including "-".
+[[nodiscard]] std::optional<Square> squareFromString(std::string_view text);
+
+// The single upper-case letter used for a piece in SAN and FEN: PNBRQK.
+// Returns '\0' for PieceType::None.
+[[nodiscard]] char toChar(PieceType type);
+
+// Accepts either case; the caller decides what the case meant.
+[[nodiscard]] std::optional<PieceType> pieceTypeFromChar(char c);
+
+// FEN piece letter: upper case for White, lower case for Black.
+[[nodiscard]] char toChar(Piece piece);
+
+[[nodiscard]] std::optional<Piece> pieceFromChar(char c);
+
+} // namespace chess

--- a/src/core/src/Board.cpp
+++ b/src/core/src/Board.cpp
@@ -1,0 +1,41 @@
+#include "chess/Board.hpp"
+
+namespace chess {
+
+Square Board::kingSquare(Color color) const
+{
+    for (int i = 0; i < kSquareCount; ++i) {
+        const auto square = static_cast<Square>(i);
+        const Piece piece = pieceAt(square);
+        if (piece.type == PieceType::King && piece.color == color) {
+            return square;
+        }
+    }
+    return Square::None;
+}
+
+Board Board::startingPosition()
+{
+    static constexpr std::array<PieceType, kBoardSize> kBackRank{
+        PieceType::Rook,
+        PieceType::Knight,
+        PieceType::Bishop,
+        PieceType::Queen,
+        PieceType::King,
+        PieceType::Bishop,
+        PieceType::Knight,
+        PieceType::Rook,
+    };
+
+    Board board;
+    for (int file = 0; file < kBoardSize; ++file) {
+        const auto backRankPiece = kBackRank[static_cast<std::size_t>(file)];
+        board.setPiece(makeSquare(file, 0), Piece{backRankPiece, Color::White});
+        board.setPiece(makeSquare(file, 1), Piece{PieceType::Pawn, Color::White});
+        board.setPiece(makeSquare(file, 6), Piece{PieceType::Pawn, Color::Black});
+        board.setPiece(makeSquare(file, 7), Piece{backRankPiece, Color::Black});
+    }
+    return board;
+}
+
+} // namespace chess

--- a/src/core/src/Fen.cpp
+++ b/src/core/src/Fen.cpp
@@ -14,16 +14,21 @@ ParseError error(std::string message)
     return ParseError{std::move(message)};
 }
 
+// Newlines count. A FEN read from a file, an .epd suite or the clipboard
+// arrives with a trailing newline, and splitting on spaces alone would fold it
+// into the last field and reject the whole record.
+constexpr std::string_view kWhitespace = " \t\n\r\v\f";
+
 std::vector<std::string_view> splitOnWhitespace(std::string_view text)
 {
     std::vector<std::string_view> fields;
     std::size_t pos = 0;
     while (pos < text.size()) {
-        const std::size_t start = text.find_first_not_of(" \t", pos);
+        const std::size_t start = text.find_first_not_of(kWhitespace, pos);
         if (start == std::string_view::npos) {
             break;
         }
-        std::size_t end = text.find_first_of(" \t", start);
+        std::size_t end = text.find_first_of(kWhitespace, start);
         if (end == std::string_view::npos) {
             end = text.size();
         }
@@ -256,8 +261,16 @@ std::string serialise(const Position& position)
         }
     }
 
+    // parse rejects an en passant target on a rank no double pawn push could
+    // have left it on. Writing such a target would produce a record this very
+    // parser refuses, so a Position built by hand with an inconsistent target
+    // is written as having none rather than as something unreadable.
+    const Rank pushedOnto = position.sideToMove == Color::White ? Rank::R6 : Rank::R3;
+    const bool targetIsCoherent
+        = isValid(position.enPassantTarget) && rankOf(position.enPassantTarget) == pushedOnto;
+
     text += ' ';
-    text += toString(position.enPassantTarget);
+    text += targetIsCoherent ? toString(position.enPassantTarget) : "-";
     text += ' ';
     text += std::to_string(position.halfmoveClock);
     text += ' ';

--- a/src/core/src/Fen.cpp
+++ b/src/core/src/Fen.cpp
@@ -1,0 +1,269 @@
+#include "chess/Fen.hpp"
+
+#include <array>
+#include <charconv>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace chess::fen {
+namespace {
+
+ParseError error(std::string message)
+{
+    return ParseError{std::move(message)};
+}
+
+std::vector<std::string_view> splitOnWhitespace(std::string_view text)
+{
+    std::vector<std::string_view> fields;
+    std::size_t pos = 0;
+    while (pos < text.size()) {
+        const std::size_t start = text.find_first_not_of(" \t", pos);
+        if (start == std::string_view::npos) {
+            break;
+        }
+        std::size_t end = text.find_first_of(" \t", start);
+        if (end == std::string_view::npos) {
+            end = text.size();
+        }
+        fields.push_back(text.substr(start, end - start));
+        pos = end;
+    }
+    return fields;
+}
+
+// Field 1: eight rank descriptions separated by '/', written from rank 8 down
+// to rank 1, each a mix of piece letters and digits that must total eight
+// squares.
+std::optional<ParseError> parsePlacement(std::string_view field, Board& board)
+{
+    board.clear();
+
+    int rank = kBoardSize - 1;
+    int file = 0;
+
+    for (const char c : field) {
+        if (c == '/') {
+            if (file != kBoardSize) {
+                return error("rank " + std::to_string(rank + 1) + " describes " + std::to_string(file)
+                    + " squares, expected 8");
+            }
+            if (rank == 0) {
+                return error("placement has more than 8 ranks");
+            }
+            --rank;
+            file = 0;
+            continue;
+        }
+
+        if (c >= '1' && c <= '8') {
+            file += c - '0';
+            if (file > kBoardSize) {
+                return error("rank " + std::to_string(rank + 1) + " overflows past the h file");
+            }
+            continue;
+        }
+
+        const auto piece = pieceFromChar(c);
+        if (!piece) {
+            return error(std::string("unknown piece letter '") + c + "'");
+        }
+        if (file >= kBoardSize) {
+            return error("rank " + std::to_string(rank + 1) + " overflows past the h file");
+        }
+        board.setPiece(makeSquare(file, rank), *piece);
+        ++file;
+    }
+
+    if (rank != 0) {
+        return error("placement has " + std::to_string(kBoardSize - rank) + " ranks, expected 8");
+    }
+    if (file != kBoardSize) {
+        return error("rank 1 describes " + std::to_string(file) + " squares, expected 8");
+    }
+    return std::nullopt;
+}
+
+std::optional<ParseError> parseCastling(std::string_view field, CastlingRights& rights)
+{
+    rights = CastlingRights{};
+    if (field == "-") {
+        return std::nullopt;
+    }
+
+    for (const char c : field) {
+        CastlingRights::Flag flag = CastlingRights::None;
+        switch (c) {
+        case 'K':
+            flag = CastlingRights::WhiteKingSide;
+            break;
+        case 'Q':
+            flag = CastlingRights::WhiteQueenSide;
+            break;
+        case 'k':
+            flag = CastlingRights::BlackKingSide;
+            break;
+        case 'q':
+            flag = CastlingRights::BlackQueenSide;
+            break;
+        default:
+            return error(std::string("unknown castling letter '") + c + "'");
+        }
+        if (rights.has(flag)) {
+            return error(std::string("castling letter '") + c + "' repeated");
+        }
+        rights.add(flag);
+    }
+    return std::nullopt;
+}
+
+// A double pawn push by White leaves a target on rank 3 with Black to move,
+// and vice versa. Anything else is a corrupt record rather than a position we
+// should try to interpret.
+std::optional<ParseError> parseEnPassant(std::string_view field, Color sideToMove, Square& target)
+{
+    target = Square::None;
+    if (field == "-") {
+        return std::nullopt;
+    }
+
+    const auto square = squareFromString(field);
+    if (!square) {
+        return error("malformed en passant target '" + std::string(field) + "'");
+    }
+
+    const Rank expected = sideToMove == Color::White ? Rank::R6 : Rank::R3;
+    if (rankOf(*square) != expected) {
+        return error("en passant target " + std::string(field) + " is not on rank "
+            + std::to_string(static_cast<int>(expected) + 1) + ", which is where a "
+            + (sideToMove == Color::White ? "Black" : "White") + " double pawn push would leave it");
+    }
+
+    target = *square;
+    return std::nullopt;
+}
+
+std::optional<ParseError> parseCounter(std::string_view field, const char* name, int minimum, int& out)
+{
+    int value = 0;
+    const char* first = field.data();
+    const char* last = field.data() + field.size();
+    const auto [ptr, ec] = std::from_chars(first, last, value);
+    if (ec != std::errc{} || ptr != last) {
+        return error(std::string(name) + " '" + std::string(field) + "' is not a number");
+    }
+    if (value < minimum) {
+        return error(std::string(name) + " must be at least " + std::to_string(minimum));
+    }
+    out = value;
+    return std::nullopt;
+}
+
+} // namespace
+
+ParseResult parse(std::string_view text)
+{
+    const std::vector<std::string_view> fields = splitOnWhitespace(text);
+    if (fields.size() < 4) {
+        return error("FEN needs at least 4 fields, found " + std::to_string(fields.size()));
+    }
+    if (fields.size() > 6) {
+        return error("FEN has " + std::to_string(fields.size()) + " fields, expected at most 6");
+    }
+
+    Position position;
+
+    if (auto failure = parsePlacement(fields[0], position.board)) {
+        return *failure;
+    }
+
+    if (fields[1] == "w") {
+        position.sideToMove = Color::White;
+    } else if (fields[1] == "b") {
+        position.sideToMove = Color::Black;
+    } else {
+        return error("side to move must be 'w' or 'b', found '" + std::string(fields[1]) + "'");
+    }
+
+    if (auto failure = parseCastling(fields[2], position.castling)) {
+        return *failure;
+    }
+
+    if (auto failure = parseEnPassant(fields[3], position.sideToMove, position.enPassantTarget)) {
+        return *failure;
+    }
+
+    // Many published test positions stop after the en passant field.
+    position.halfmoveClock = 0;
+    position.fullmoveNumber = 1;
+
+    if (fields.size() >= 5) {
+        if (auto failure = parseCounter(fields[4], "halfmove clock", 0, position.halfmoveClock)) {
+            return *failure;
+        }
+    }
+    if (fields.size() == 6) {
+        if (auto failure = parseCounter(fields[5], "fullmove number", 1, position.fullmoveNumber)) {
+            return *failure;
+        }
+    }
+
+    return position;
+}
+
+std::string serialise(const Position& position)
+{
+    std::string text;
+
+    for (int rank = kBoardSize - 1; rank >= 0; --rank) {
+        int emptyRun = 0;
+        for (int file = 0; file < kBoardSize; ++file) {
+            const Piece piece = position.board.pieceAt(makeSquare(file, rank));
+            if (piece.isEmpty()) {
+                ++emptyRun;
+                continue;
+            }
+            if (emptyRun > 0) {
+                text += static_cast<char>('0' + emptyRun);
+                emptyRun = 0;
+            }
+            text += toChar(piece);
+        }
+        if (emptyRun > 0) {
+            text += static_cast<char>('0' + emptyRun);
+        }
+        if (rank > 0) {
+            text += '/';
+        }
+    }
+
+    text += position.sideToMove == Color::White ? " w " : " b ";
+
+    if (position.castling == CastlingRights{}) {
+        text += '-';
+    } else {
+        static constexpr std::array<std::pair<CastlingRights::Flag, char>, 4> kOrder{{
+            {CastlingRights::WhiteKingSide, 'K'},
+            {CastlingRights::WhiteQueenSide, 'Q'},
+            {CastlingRights::BlackKingSide, 'k'},
+            {CastlingRights::BlackQueenSide, 'q'},
+        }};
+        for (const auto& [flag, letter] : kOrder) {
+            if (position.castling.has(flag)) {
+                text += letter;
+            }
+        }
+    }
+
+    text += ' ';
+    text += toString(position.enPassantTarget);
+    text += ' ';
+    text += std::to_string(position.halfmoveClock);
+    text += ' ';
+    text += std::to_string(position.fullmoveNumber);
+
+    return text;
+}
+
+} // namespace chess::fen

--- a/src/core/src/Move.cpp
+++ b/src/core/src/Move.cpp
@@ -28,6 +28,11 @@ std::optional<Move> Move::fromUci(std::string_view text)
     if (!from || !to) {
         return std::nullopt;
     }
+    // No piece may move to where it already stands. UCI writes the null move
+    // as "0000", which is not a square pair and is rejected above.
+    if (*from == *to) {
+        return std::nullopt;
+    }
 
     Move move;
     move.from = *from;

--- a/src/core/src/Move.cpp
+++ b/src/core/src/Move.cpp
@@ -1,0 +1,51 @@
+#include "chess/Move.hpp"
+
+#include <cctype>
+
+namespace chess {
+
+std::string Move::toUci() const
+{
+    if (!isValid()) {
+        return "0000";
+    }
+    std::string text = toString(from) + toString(to);
+    if (isPromotion()) {
+        const char letter = toChar(promotion);
+        text += static_cast<char>(std::tolower(static_cast<unsigned char>(letter)));
+    }
+    return text;
+}
+
+std::optional<Move> Move::fromUci(std::string_view text)
+{
+    if (text.size() != 4 && text.size() != 5) {
+        return std::nullopt;
+    }
+
+    const auto from = squareFromString(text.substr(0, 2));
+    const auto to = squareFromString(text.substr(2, 2));
+    if (!from || !to) {
+        return std::nullopt;
+    }
+
+    Move move;
+    move.from = *from;
+    move.to = *to;
+
+    if (text.size() == 5) {
+        const auto promotion = pieceTypeFromChar(text[4]);
+        if (!promotion) {
+            return std::nullopt;
+        }
+        // A pawn cannot promote to a pawn or to a king.
+        if (*promotion == PieceType::Pawn || *promotion == PieceType::King) {
+            return std::nullopt;
+        }
+        move.promotion = *promotion;
+    }
+
+    return move;
+}
+
+} // namespace chess

--- a/src/core/src/Position.cpp
+++ b/src/core/src/Position.cpp
@@ -1,0 +1,28 @@
+#include "chess/Position.hpp"
+
+namespace chess {
+
+Position Position::starting()
+{
+    Position position;
+    position.board = Board::startingPosition();
+    position.sideToMove = Color::White;
+    position.castling = CastlingRights{CastlingRights::All};
+    position.enPassantTarget = Square::None;
+    position.halfmoveClock = 0;
+    position.fullmoveNumber = 1;
+    return position;
+}
+
+bool Position::sameGameState(const Position& other) const
+{
+    return board == other.board && sideToMove == other.sideToMove && castling == other.castling
+        && enPassantTarget == other.enPassantTarget;
+}
+
+bool operator==(const Position& a, const Position& b)
+{
+    return a.sameGameState(b) && a.halfmoveClock == b.halfmoveClock && a.fullmoveNumber == b.fullmoveNumber;
+}
+
+} // namespace chess

--- a/src/core/src/Types.cpp
+++ b/src/core/src/Types.cpp
@@ -1,0 +1,98 @@
+#include "chess/Types.hpp"
+
+namespace chess {
+
+std::string toString(Square s)
+{
+    if (!isValid(s)) {
+        return "-";
+    }
+    const auto file = static_cast<char>('a' + static_cast<int>(fileOf(s)));
+    const auto rank = static_cast<char>('1' + static_cast<int>(rankOf(s)));
+    return std::string{file, rank};
+}
+
+std::optional<Square> squareFromString(std::string_view text)
+{
+    if (text.size() != 2) {
+        return std::nullopt;
+    }
+    const int file = text[0] - 'a';
+    const int rank = text[1] - '1';
+    const Square square = makeSquare(file, rank);
+    if (!isValid(square)) {
+        return std::nullopt;
+    }
+    return square;
+}
+
+char toChar(PieceType type)
+{
+    switch (type) {
+    case PieceType::Pawn:
+        return 'P';
+    case PieceType::Knight:
+        return 'N';
+    case PieceType::Bishop:
+        return 'B';
+    case PieceType::Rook:
+        return 'R';
+    case PieceType::Queen:
+        return 'Q';
+    case PieceType::King:
+        return 'K';
+    case PieceType::None:
+        break;
+    }
+    return '\0';
+}
+
+std::optional<PieceType> pieceTypeFromChar(char c)
+{
+    switch (c) {
+    case 'P':
+    case 'p':
+        return PieceType::Pawn;
+    case 'N':
+    case 'n':
+        return PieceType::Knight;
+    case 'B':
+    case 'b':
+        return PieceType::Bishop;
+    case 'R':
+    case 'r':
+        return PieceType::Rook;
+    case 'Q':
+    case 'q':
+        return PieceType::Queen;
+    case 'K':
+    case 'k':
+        return PieceType::King;
+    default:
+        return std::nullopt;
+    }
+}
+
+char toChar(Piece piece)
+{
+    const char letter = toChar(piece.type);
+    if (letter == '\0') {
+        return '\0';
+    }
+    if (piece.color == Color::Black) {
+        return static_cast<char>(letter - 'A' + 'a');
+    }
+    return letter;
+}
+
+std::optional<Piece> pieceFromChar(char c)
+{
+    const auto type = pieceTypeFromChar(c);
+    if (!type) {
+        return std::nullopt;
+    }
+    const Color color = (c >= 'a' && c <= 'z') ? Color::Black : Color::White;
+    return Piece{*type, color};
+}
+
+} // namespace chess

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,30 @@
+include(FetchContent)
+
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
+
+FetchContent_Declare(googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.17.0
+  GIT_SHALLOW TRUE
+  SYSTEM
+)
+FetchContent_MakeAvailable(googletest)
+
+include(GoogleTest)
+
+# One test binary per area of the core. Keeping them separate means a failure
+# names the area, and ctest can run them in parallel.
+function(cines_add_core_test name)
+  add_executable(${name} ${ARGN})
+  target_link_libraries(${name} PRIVATE cines::core cines_warnings GTest::gtest_main)
+  gtest_discover_tests(${name}
+    PROPERTIES LABELS core
+    DISCOVERY_TIMEOUT 30)
+endfunction()
+
+cines_add_core_test(core_types_test types_test.cpp)
+cines_add_core_test(core_board_test board_test.cpp)
+cines_add_core_test(core_move_test move_test.cpp)
+cines_add_core_test(core_fen_test fen_test.cpp)

--- a/tests/board_test.cpp
+++ b/tests/board_test.cpp
@@ -1,0 +1,124 @@
+#include "chess/Board.hpp"
+#include "chess/Position.hpp"
+
+#include <gtest/gtest.h>
+
+namespace chess {
+namespace {
+
+TEST(Board, DefaultIsEmpty)
+{
+    const Board board;
+    for (int i = 0; i < kSquareCount; ++i) {
+        EXPECT_TRUE(board.isEmpty(static_cast<Square>(i)));
+    }
+    EXPECT_EQ(board.kingSquare(Color::White), Square::None);
+}
+
+TEST(Board, StartingPositionPlacesWhiteOnRanksOneAndTwo)
+{
+    const Board board = Board::startingPosition();
+
+    EXPECT_EQ(board.pieceAt(Square::A1), (Piece{PieceType::Rook, Color::White}));
+    EXPECT_EQ(board.pieceAt(Square::B1), (Piece{PieceType::Knight, Color::White}));
+    EXPECT_EQ(board.pieceAt(Square::C1), (Piece{PieceType::Bishop, Color::White}));
+    EXPECT_EQ(board.pieceAt(Square::D1), (Piece{PieceType::Queen, Color::White}));
+    EXPECT_EQ(board.pieceAt(Square::E1), (Piece{PieceType::King, Color::White}));
+    EXPECT_EQ(board.pieceAt(Square::E2), (Piece{PieceType::Pawn, Color::White}));
+}
+
+TEST(Board, StartingPositionPlacesBlackOnRanksSevenAndEight)
+{
+    const Board board = Board::startingPosition();
+
+    EXPECT_EQ(board.pieceAt(Square::E7), (Piece{PieceType::Pawn, Color::Black}));
+    EXPECT_EQ(board.pieceAt(Square::D8), (Piece{PieceType::Queen, Color::Black}));
+    EXPECT_EQ(board.pieceAt(Square::E8), (Piece{PieceType::King, Color::Black}));
+}
+
+// The 2012 code recorded the white king at row 7 while placing white's pieces
+// on rows 0 and 1. Asserting both kings explicitly keeps that class of
+// off-by-a-side error out.
+TEST(Board, KingSquareFindsEachKingOnItsOwnSide)
+{
+    const Board board = Board::startingPosition();
+    EXPECT_EQ(board.kingSquare(Color::White), Square::E1);
+    EXPECT_EQ(board.kingSquare(Color::Black), Square::E8);
+}
+
+TEST(Board, StartingPositionLeavesTheMiddleFourRanksEmpty)
+{
+    const Board board = Board::startingPosition();
+    for (int rank = 2; rank <= 5; ++rank) {
+        for (int file = 0; file < kBoardSize; ++file) {
+            EXPECT_TRUE(board.isEmpty(makeSquare(file, rank))) << "rank " << rank + 1 << " file " << file;
+        }
+    }
+}
+
+TEST(Board, HasPieceOfIsFalseForEmptySquares)
+{
+    const Board board = Board::startingPosition();
+    EXPECT_TRUE(board.hasPieceOf(Square::E2, Color::White));
+    EXPECT_FALSE(board.hasPieceOf(Square::E2, Color::Black));
+    EXPECT_FALSE(board.hasPieceOf(Square::E4, Color::White));
+    EXPECT_FALSE(board.hasPieceOf(Square::E4, Color::Black));
+}
+
+TEST(Board, SetAndClearSquare)
+{
+    Board board;
+    board.setPiece(Square::D4, Piece{PieceType::Queen, Color::Black});
+    EXPECT_EQ(board.pieceAt(Square::D4), (Piece{PieceType::Queen, Color::Black}));
+    board.clearSquare(Square::D4);
+    EXPECT_TRUE(board.isEmpty(Square::D4));
+}
+
+TEST(CastlingRights, FlagsAreIndependent)
+{
+    CastlingRights rights{CastlingRights::All};
+    EXPECT_TRUE(rights.has(CastlingRights::WhiteKingSide));
+    EXPECT_TRUE(rights.has(CastlingRights::BlackQueenSide));
+
+    rights.remove(CastlingRights::WhiteKingSide);
+    EXPECT_FALSE(rights.has(CastlingRights::WhiteKingSide));
+    EXPECT_TRUE(rights.has(CastlingRights::WhiteQueenSide));
+    EXPECT_TRUE(rights.has(CastlingRights::BlackKingSide));
+}
+
+TEST(CastlingRights, PerColourAccessors)
+{
+    EXPECT_EQ(CastlingRights::kingSideFor(Color::White), CastlingRights::WhiteKingSide);
+    EXPECT_EQ(CastlingRights::kingSideFor(Color::Black), CastlingRights::BlackKingSide);
+    EXPECT_EQ(CastlingRights::queenSideFor(Color::White), CastlingRights::WhiteQueenSide);
+    EXPECT_EQ(CastlingRights::queenSideFor(Color::Black), CastlingRights::BlackQueenSide);
+}
+
+TEST(Position, StartingPositionHasAllRightsAndNoEnPassant)
+{
+    const Position position = Position::starting();
+    EXPECT_EQ(position.sideToMove, Color::White);
+    EXPECT_EQ(position.castling, CastlingRights{CastlingRights::All});
+    EXPECT_EQ(position.enPassantTarget, Square::None);
+    EXPECT_EQ(position.halfmoveClock, 0);
+    EXPECT_EQ(position.fullmoveNumber, 1);
+}
+
+// Threefold repetition compares positions, not move numbers. Two positions
+// that differ only in the counters are the same position for that rule.
+TEST(Position, SameGameStateIgnoresTheCounters)
+{
+    Position a = Position::starting();
+    Position b = Position::starting();
+    b.halfmoveClock = 12;
+    b.fullmoveNumber = 40;
+
+    EXPECT_TRUE(a.sameGameState(b));
+    EXPECT_FALSE(a == b);
+
+    b.sideToMove = Color::Black;
+    EXPECT_FALSE(a.sameGameState(b));
+}
+
+} // namespace
+} // namespace chess

--- a/tests/fen_test.cpp
+++ b/tests/fen_test.cpp
@@ -1,0 +1,218 @@
+#include "chess/Fen.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+
+namespace chess {
+namespace {
+
+// Unwraps a parse that is expected to succeed, failing the test with the
+// parser's own message when it does not.
+Position mustParse(std::string_view text)
+{
+    fen::ParseResult result = fen::parse(text);
+    if (const auto* failure = std::get_if<fen::ParseError>(&result)) {
+        ADD_FAILURE() << "expected '" << text << "' to parse, got: " << failure->message;
+        return Position{};
+    }
+    return std::get<Position>(result);
+}
+
+std::string parseErrorFor(std::string_view text)
+{
+    fen::ParseResult result = fen::parse(text);
+    if (const auto* failure = std::get_if<fen::ParseError>(&result)) {
+        return failure->message;
+    }
+    ADD_FAILURE() << "expected '" << text << "' to be rejected, but it parsed";
+    return {};
+}
+
+// The six positions the Chess Programming Wiki publishes perft results for.
+// PR 2 walks these to a known node count; here they only need to survive a
+// round trip, which is what makes those later numbers trustworthy.
+constexpr std::string_view kStartPosition = fen::kStartingPosition;
+constexpr std::string_view kKiwipete = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1";
+constexpr std::string_view kPosition3 = "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1";
+constexpr std::string_view kPosition4 = "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1";
+constexpr std::string_view kPosition5 = "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8";
+constexpr std::string_view kPosition6
+    = "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10";
+
+TEST(Fen, StartingPositionMatchesTheBoardBuiltInCode)
+{
+    const Position parsed = mustParse(kStartPosition);
+    EXPECT_EQ(parsed, Position::starting());
+}
+
+TEST(Fen, SerialisesTheStartingPosition)
+{
+    EXPECT_EQ(fen::serialise(Position::starting()), kStartPosition);
+}
+
+TEST(Fen, RoundTripsTheStandardPerftPositions)
+{
+    for (const std::string_view text :
+        {kStartPosition, kKiwipete, kPosition3, kPosition4, kPosition5, kPosition6}) {
+        const Position parsed = mustParse(text);
+        EXPECT_EQ(fen::serialise(parsed), text);
+        EXPECT_EQ(mustParse(fen::serialise(parsed)), parsed);
+    }
+}
+
+TEST(Fen, ReadsSideToMove)
+{
+    EXPECT_EQ(mustParse("8/8/8/8/8/8/8/K6k w - - 0 1").sideToMove, Color::White);
+    EXPECT_EQ(mustParse("8/8/8/8/8/8/8/K6k b - - 0 1").sideToMove, Color::Black);
+}
+
+TEST(Fen, ReadsEachCastlingRightsSubset)
+{
+    const auto rightsFor = [](std::string_view field) {
+        return mustParse("r3k2r/8/8/8/8/8/8/R3K2R w " + std::string(field) + " - 0 1").castling;
+    };
+
+    EXPECT_EQ(rightsFor("-"), CastlingRights{});
+    EXPECT_EQ(rightsFor("KQkq"), CastlingRights{CastlingRights::All});
+
+    const CastlingRights whiteOnly = rightsFor("KQ");
+    EXPECT_TRUE(whiteOnly.has(CastlingRights::WhiteKingSide));
+    EXPECT_TRUE(whiteOnly.has(CastlingRights::WhiteQueenSide));
+    EXPECT_FALSE(whiteOnly.has(CastlingRights::BlackKingSide));
+    EXPECT_FALSE(whiteOnly.has(CastlingRights::BlackQueenSide));
+
+    const CastlingRights queenSides = rightsFor("Qq");
+    EXPECT_FALSE(queenSides.has(CastlingRights::WhiteKingSide));
+    EXPECT_TRUE(queenSides.has(CastlingRights::WhiteQueenSide));
+    EXPECT_FALSE(queenSides.has(CastlingRights::BlackKingSide));
+    EXPECT_TRUE(queenSides.has(CastlingRights::BlackQueenSide));
+
+    const CastlingRights blackKingOnly = rightsFor("k");
+    EXPECT_EQ(blackKingOnly.bits(), static_cast<std::uint8_t>(CastlingRights::BlackKingSide));
+}
+
+TEST(Fen, SerialisesCastlingRightsInKQkqOrder)
+{
+    Position position = Position::starting();
+    position.castling.remove(CastlingRights::WhiteKingSide);
+    position.castling.remove(CastlingRights::BlackQueenSide);
+    EXPECT_EQ(fen::serialise(position), "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w Qk - 0 1");
+
+    position.castling = CastlingRights{};
+    EXPECT_EQ(fen::serialise(position), "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1");
+}
+
+// A White double push leaves a target on rank 3 with Black to move; a Black
+// one leaves it on rank 6 with White to move.
+TEST(Fen, ReadsEnPassantTargetsOnBothSides)
+{
+    const Position afterE4 = mustParse("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1");
+    EXPECT_EQ(afterE4.enPassantTarget, Square::E3);
+    EXPECT_EQ(afterE4.sideToMove, Color::Black);
+
+    const Position afterE5 = mustParse("rnbqkbnr/pppp1ppp/8/4p3/8/8/PPPPPPPP/RNBQKBNR w KQkq e6 0 2");
+    EXPECT_EQ(afterE5.enPassantTarget, Square::E6);
+    EXPECT_EQ(afterE5.sideToMove, Color::White);
+}
+
+TEST(Fen, RejectsAnEnPassantTargetOnTheWrongRankForTheSideToMove)
+{
+    // e6 with Black to move would mean Black just pushed onto its own side.
+    EXPECT_FALSE(parseErrorFor("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq e6 0 1").empty());
+    EXPECT_FALSE(parseErrorFor("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq e3 0 1").empty());
+    EXPECT_FALSE(parseErrorFor("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq e4 0 1").empty());
+}
+
+TEST(Fen, ReadsTheMoveCounters)
+{
+    const Position position = mustParse("8/8/8/8/8/8/8/K6k w - - 37 99");
+    EXPECT_EQ(position.halfmoveClock, 37);
+    EXPECT_EQ(position.fullmoveNumber, 99);
+}
+
+// Many published test positions stop after the en passant field.
+TEST(Fen, AcceptsARecordWithoutCounters)
+{
+    const Position position = mustParse("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - -");
+    EXPECT_EQ(position.halfmoveClock, 0);
+    EXPECT_EQ(position.fullmoveNumber, 1);
+    EXPECT_EQ(fen::serialise(position), kPosition3);
+}
+
+TEST(Fen, ToleratesRepeatedSpacesBetweenFields)
+{
+    EXPECT_EQ(
+        mustParse("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR  w   KQkq  -  0  1"), Position::starting());
+}
+
+TEST(Fen, RejectsTooFewFields)
+{
+    EXPECT_FALSE(parseErrorFor("").empty());
+    EXPECT_FALSE(parseErrorFor("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR").empty());
+    EXPECT_FALSE(parseErrorFor("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq").empty());
+}
+
+TEST(Fen, RejectsTooManyFields)
+{
+    EXPECT_FALSE(parseErrorFor("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 extra").empty());
+}
+
+TEST(Fen, RejectsTheWrongNumberOfRanks)
+{
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8 w - - 0 1").empty());
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/8/8 w - - 0 1").empty());
+}
+
+TEST(Fen, RejectsARankThatDoesNotDescribeEightSquares)
+{
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/7 w - - 0 1").empty());
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/9 w - - 0 1").empty());
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/8P w - - 0 1").empty());
+    EXPECT_FALSE(parseErrorFor("KKKKKKKKK/8/8/8/8/8/8/8 w - - 0 1").empty());
+}
+
+TEST(Fen, RejectsUnknownPieceLetters)
+{
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/X7 w - - 0 1").empty());
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/07 w - - 0 1").empty());
+}
+
+TEST(Fen, RejectsAMalformedSideToMove)
+{
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k W - - 0 1").empty());
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k white - - 0 1").empty());
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k x - - 0 1").empty());
+}
+
+TEST(Fen, RejectsAMalformedCastlingField)
+{
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k w KQkqX - 0 1").empty());
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k w KK - 0 1").empty());
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k w K- - 0 1").empty());
+}
+
+TEST(Fen, RejectsAMalformedEnPassantField)
+{
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k w - e 0 1").empty());
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k w - i6 0 1").empty());
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k w - e66 0 1").empty());
+}
+
+TEST(Fen, RejectsMalformedCounters)
+{
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k w - - x 1").empty());
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k w - - -1 1").empty());
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k w - - 0 0").empty());
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k w - - 0 1x").empty());
+}
+
+TEST(Fen, ErrorMessagesNameTheProblem)
+{
+    EXPECT_NE(parseErrorFor("8/8/8/8/8/8/8/X7 w - - 0 1").find('X'), std::string::npos);
+    EXPECT_NE(parseErrorFor("8/8/8/8/8/8/8/K6k q - - 0 1").find("side to move"), std::string::npos);
+}
+
+} // namespace
+} // namespace chess

--- a/tests/fen_test.cpp
+++ b/tests/fen_test.cpp
@@ -147,6 +147,57 @@ TEST(Fen, ToleratesRepeatedSpacesBetweenFields)
         mustParse("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR  w   KQkq  -  0  1"), Position::starting());
 }
 
+// A record read from a file, an .epd suite or the clipboard arrives with a
+// trailing newline. Splitting on spaces alone would fold it into the last
+// field and reject the whole thing.
+TEST(Fen, ToleratesTabsAndTrailingNewlines)
+{
+    EXPECT_EQ(mustParse(std::string(kStartPosition) + "\n"), Position::starting());
+    EXPECT_EQ(mustParse(std::string(kStartPosition) + "\r\n"), Position::starting());
+    EXPECT_EQ(mustParse("\n  " + std::string(kStartPosition) + "  \n"), Position::starting());
+    EXPECT_EQ(
+        mustParse("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR\tw\tKQkq\t-\t0\t1"), Position::starting());
+}
+
+// Five fields means the halfmove clock is present and the fullmove number is
+// not, which sits between the two cases the other tests cover.
+TEST(Fen, AcceptsFiveFields)
+{
+    const Position position = mustParse("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 7");
+    EXPECT_EQ(position.halfmoveClock, 7);
+    EXPECT_EQ(position.fullmoveNumber, 1);
+}
+
+TEST(Fen, RejectsCountersTooLargeForTheType)
+{
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k w - - 99999999999 1").empty());
+    EXPECT_FALSE(parseErrorFor("8/8/8/8/8/8/8/K6k w - - 0 99999999999").empty());
+}
+
+// Every other round-trip test uses a position with no en passant target, so
+// this is the one that exercises that field of serialise.
+TEST(Fen, RoundTripsAPositionWithAnEnPassantTarget)
+{
+    constexpr std::string_view afterE4 = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1";
+    const Position position = mustParse(afterE4);
+    EXPECT_EQ(position.enPassantTarget, Square::E3);
+    EXPECT_EQ(fen::serialise(position), afterE4);
+    EXPECT_EQ(mustParse(fen::serialise(position)), position);
+}
+
+// A Position built by hand can hold an en passant target that no double pawn
+// push could have produced. parse refuses such a record, so serialise must not
+// write one, or the two would disagree about what a valid position is.
+TEST(Fen, WritesNoEnPassantTargetWhenItContradictsTheSideToMove)
+{
+    Position position = Position::starting();
+    position.enPassantTarget = Square::E3; // White to move: only e6 could be right.
+
+    const std::string text = fen::serialise(position);
+    EXPECT_EQ(text, kStartPosition);
+    EXPECT_TRUE(std::holds_alternative<Position>(fen::parse(text)));
+}
+
 TEST(Fen, RejectsTooFewFields)
 {
     EXPECT_FALSE(parseErrorFor("").empty());

--- a/tests/move_test.cpp
+++ b/tests/move_test.cpp
@@ -1,0 +1,89 @@
+#include "chess/Move.hpp"
+
+#include <gtest/gtest.h>
+
+namespace chess {
+namespace {
+
+TEST(Move, UciRoundTripForAPlainMove)
+{
+    const Move move{Square::E2, Square::E4, PieceType::None, MoveKind::DoublePawnPush};
+    EXPECT_EQ(move.toUci(), "e2e4");
+
+    const auto parsed = Move::fromUci("e2e4");
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(*parsed, move);
+}
+
+TEST(Move, UciPromotionLetterIsLowerCase)
+{
+    const Move move{Square::E7, Square::E8, PieceType::Queen, MoveKind::Quiet};
+    EXPECT_EQ(move.toUci(), "e7e8q");
+
+    const auto parsed = Move::fromUci("e7e8q");
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(parsed->promotion, PieceType::Queen);
+}
+
+TEST(Move, UciAcceptsUpperCasePromotionLetters)
+{
+    const auto parsed = Move::fromUci("a7a8N");
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(parsed->promotion, PieceType::Knight);
+}
+
+TEST(Move, UciRejectsPromotionToPawnOrKing)
+{
+    EXPECT_FALSE(Move::fromUci("e7e8p").has_value());
+    EXPECT_FALSE(Move::fromUci("e7e8k").has_value());
+}
+
+TEST(Move, UciRejectsMalformedInput)
+{
+    EXPECT_FALSE(Move::fromUci("").has_value());
+    EXPECT_FALSE(Move::fromUci("e2e").has_value());
+    EXPECT_FALSE(Move::fromUci("e2e4qq").has_value());
+    EXPECT_FALSE(Move::fromUci("i2e4").has_value());
+    EXPECT_FALSE(Move::fromUci("e2e9").has_value());
+    EXPECT_FALSE(Move::fromUci("e2e4x").has_value());
+}
+
+TEST(Move, InvalidMoveSerialisesToTheNullMove)
+{
+    EXPECT_EQ(Move{}.toUci(), "0000");
+    EXPECT_FALSE(Move{}.isValid());
+}
+
+// Kind is derived from the position, so it is deliberately not part of move
+// identity. This is what lets the user interface look a click up in a
+// generated list without knowing how to classify it.
+TEST(Move, IdentityIgnoresKind)
+{
+    const Move quiet{Square::E1, Square::G1, PieceType::None, MoveKind::Quiet};
+    const Move castle{Square::E1, Square::G1, PieceType::None, MoveKind::CastleKingSide};
+    EXPECT_EQ(quiet, castle);
+}
+
+TEST(Move, IdentityIncludesThePromotionPiece)
+{
+    const Move toQueen{Square::E7, Square::E8, PieceType::Queen, MoveKind::Quiet};
+    const Move toKnight{Square::E7, Square::E8, PieceType::Knight, MoveKind::Quiet};
+    EXPECT_NE(toQueen, toKnight);
+}
+
+TEST(Move, ClassifiersMatchTheKind)
+{
+    EXPECT_TRUE((Move{Square::E1, Square::G1, PieceType::None, MoveKind::CastleKingSide}).isCastle());
+    EXPECT_TRUE((Move{Square::E1, Square::C1, PieceType::None, MoveKind::CastleQueenSide}).isCastle());
+    EXPECT_FALSE((Move{Square::E2, Square::E4, PieceType::None, MoveKind::DoublePawnPush}).isCastle());
+
+    EXPECT_TRUE((Move{Square::D5, Square::E6, PieceType::None, MoveKind::EnPassant}).isCapture());
+    EXPECT_TRUE((Move{Square::D5, Square::E6, PieceType::None, MoveKind::Capture}).isCapture());
+    EXPECT_FALSE((Move{Square::D5, Square::D6, PieceType::None, MoveKind::Quiet}).isCapture());
+
+    EXPECT_TRUE((Move{Square::E7, Square::E8, PieceType::Queen, MoveKind::Quiet}).isPromotion());
+    EXPECT_FALSE((Move{Square::E7, Square::E8, PieceType::None, MoveKind::Quiet}).isPromotion());
+}
+
+} // namespace
+} // namespace chess

--- a/tests/move_test.cpp
+++ b/tests/move_test.cpp
@@ -38,6 +38,14 @@ TEST(Move, UciRejectsPromotionToPawnOrKing)
     EXPECT_FALSE(Move::fromUci("e7e8k").has_value());
 }
 
+// No piece may move to where it already stands, so "e2e2" names nothing.
+TEST(Move, UciRejectsAMoveThatGoesNowhere)
+{
+    EXPECT_FALSE(Move::fromUci("e2e2").has_value());
+    EXPECT_FALSE(Move::fromUci("a1a1").has_value());
+    EXPECT_FALSE(Move::fromUci("0000").has_value()) << "UCI's null move is not a move we can play";
+}
+
 TEST(Move, UciRejectsMalformedInput)
 {
     EXPECT_FALSE(Move::fromUci("").has_value());

--- a/tests/types_test.cpp
+++ b/tests/types_test.cpp
@@ -1,0 +1,110 @@
+#include "chess/Types.hpp"
+
+#include <gtest/gtest.h>
+
+namespace chess {
+namespace {
+
+TEST(Square, IndexesFromA1ToH8)
+{
+    EXPECT_EQ(index(Square::A1), 0);
+    EXPECT_EQ(index(Square::H1), 7);
+    EXPECT_EQ(index(Square::A2), 8);
+    EXPECT_EQ(index(Square::E4), 28);
+    EXPECT_EQ(index(Square::H8), 63);
+}
+
+TEST(Square, FileAndRankRoundTrip)
+{
+    for (int i = 0; i < kSquareCount; ++i) {
+        const auto square = static_cast<Square>(i);
+        EXPECT_EQ(makeSquare(fileOf(square), rankOf(square)), square);
+    }
+}
+
+TEST(Square, MakeSquareRejectsCoordinatesOffTheBoard)
+{
+    EXPECT_EQ(makeSquare(-1, 0), Square::None);
+    EXPECT_EQ(makeSquare(0, -1), Square::None);
+    EXPECT_EQ(makeSquare(8, 0), Square::None);
+    EXPECT_EQ(makeSquare(0, 8), Square::None);
+    EXPECT_EQ(makeSquare(4, 3), Square::E4);
+}
+
+TEST(Square, NamesRoundTrip)
+{
+    for (int i = 0; i < kSquareCount; ++i) {
+        const auto square = static_cast<Square>(i);
+        const auto parsed = squareFromString(toString(square));
+        ASSERT_TRUE(parsed.has_value()) << toString(square);
+        EXPECT_EQ(*parsed, square);
+    }
+    EXPECT_EQ(toString(Square::E4), "e4");
+    EXPECT_EQ(toString(Square::None), "-");
+}
+
+TEST(Square, RejectsMalformedNames)
+{
+    EXPECT_FALSE(squareFromString("").has_value());
+    EXPECT_FALSE(squareFromString("-").has_value());
+    EXPECT_FALSE(squareFromString("e").has_value());
+    EXPECT_FALSE(squareFromString("e44").has_value());
+    EXPECT_FALSE(squareFromString("i4").has_value());
+    EXPECT_FALSE(squareFromString("e9").has_value());
+    EXPECT_FALSE(squareFromString("E4").has_value());
+}
+
+TEST(Piece, EmptySquaresCompareEqualRegardlessOfColour)
+{
+    EXPECT_EQ((Piece{}), (Piece{PieceType::None, Color::Black}));
+    EXPECT_TRUE(Piece{}.isEmpty());
+    EXPECT_FALSE((Piece{PieceType::Pawn, Color::White}).isEmpty());
+}
+
+TEST(Piece, ColourIsPartOfIdentityForRealPieces)
+{
+    EXPECT_NE((Piece{PieceType::Pawn, Color::White}), (Piece{PieceType::Pawn, Color::Black}));
+    EXPECT_EQ((Piece{PieceType::Pawn, Color::White}), (Piece{PieceType::Pawn, Color::White}));
+}
+
+TEST(Piece, FenLettersRoundTrip)
+{
+    for (const auto type : {PieceType::Pawn, PieceType::Knight, PieceType::Bishop, PieceType::Rook,
+             PieceType::Queen, PieceType::King}) {
+        for (const auto color : {Color::White, Color::Black}) {
+            const Piece piece{type, color};
+            const auto parsed = pieceFromChar(toChar(piece));
+            ASSERT_TRUE(parsed.has_value());
+            EXPECT_EQ(*parsed, piece);
+        }
+    }
+    EXPECT_EQ(toChar(Piece{PieceType::Knight, Color::White}), 'N');
+    EXPECT_EQ(toChar(Piece{PieceType::Knight, Color::Black}), 'n');
+    EXPECT_EQ(toChar(PieceType::None), '\0');
+}
+
+TEST(Piece, RejectsUnknownLetters)
+{
+    EXPECT_FALSE(pieceFromChar('x').has_value());
+    EXPECT_FALSE(pieceFromChar('1').has_value());
+    EXPECT_FALSE(pieceFromChar('-').has_value());
+}
+
+TEST(Color, OppositeIsAnInvolution)
+{
+    EXPECT_EQ(opposite(Color::White), Color::Black);
+    EXPECT_EQ(opposite(opposite(Color::White)), Color::White);
+}
+
+TEST(Pawns, StartPromotionRanksAndDirectionMatchColour)
+{
+    EXPECT_EQ(pawnStartRank(Color::White), Rank::R2);
+    EXPECT_EQ(pawnStartRank(Color::Black), Rank::R7);
+    EXPECT_EQ(promotionRank(Color::White), Rank::R8);
+    EXPECT_EQ(promotionRank(Color::Black), Rank::R1);
+    EXPECT_EQ(pawnPush(Color::White), 1);
+    EXPECT_EQ(pawnPush(Color::Black), -1);
+}
+
+} // namespace
+} // namespace chess


### PR DESCRIPTION
First of six stacked PRs modernizing CINES.
Merge in order; each is green on CI on its own.

| # | Branch | Contents |
|---|--------|----------|
| **1** | `modernize/01-core-build-ci` | **CMake build, core value types, FEN, CI** |
| 2 | `modernize/02-rules-perft` | Full FIDE rules, SAN/PGN/Game, perft |
| 3 | `modernize/03-qt-app` | Qt 6 Widgets front end; legacy files deleted |
| 4 | `modernize/04-board-ux` | Themes, move affordances, animation |
| 5 | `modernize/05-side-panel` | Move list, captured tray, menus |
| 6 | `modernize/06-release` | AppImage, Windows zip, macOS DMG, Homebrew tap |

## Why

The 2012 core cannot carry a modernization.
Reading the 1,240 tracked lines shows why:

- Game state lives in globals named `exp[60]` and `max` (`main.cpp:5`),
which shadow `<cmath>` symbols.
- `chessBoard()` calls `border[0]->outline(...)` on a null pointer array (`main.cpp:59-67`) —
undefined behaviour that survives only because `outline` never touches `this`.
- `validation::check()` returns 0 unconditionally (`validation.cpp:654`),
so check, checkmate and stalemate do not exist.
Neither do castling, en passant or promotion,
and a player may move into check.
- `Tile` is model, view and controller at once —
a `QLabel` subclass holding `piece`, `pieceColor`, `row`, `col` and its own `mousePressEvent` (`tile.h:6-22`).
Nothing in it can be tested without a display.
- `main.cpp:92-93` sets White to `pieceColor=0`
while `tile.cpp:23` treats a truthy `pieceColor` as White.
`validation.cpp` only ever compares colours relatively, which hides the disagreement.
- `Qt::WindowFlags f=0` (`tile.h:15-16`) does not compile under Qt 6.

## What this PR does

Starts the replacement with a static library that **includes no Qt header**.
That single constraint is what makes the rules unit-testable
and what will let the user interface be replaced without touching them.

Responsibilities are split rather than pooled:

| Type | Owns |
|---|---|
| `Board` | piece placement, and nothing else |
| `Position` | placement plus side to move, castling rights, en passant, clocks |
| `Move` | from, to, promotion, and the *kind* of move it is |
| `Fen` | the standard text form, parsed strictly and serialised back |

`Move` carries its kind so applying it needs no re-derivation from the board.
An en passant capture removes a pawn that is not on the destination square,
and a castle moves two pieces;
deciding that after the fact is exactly the reasoning the old code got wrong.

`Position::sameGameState` deliberately ignores the move counters,
because threefold repetition compares positions, not move numbers.

FEN rejects rather than repairs:
the wrong number of ranks,
a rank that does not describe eight squares,
an unknown piece letter,
a repeated castling letter,
and an en passant target on a rank no double pawn push could have left it on.
Counters are optional, since many published test positions omit them.

Also here: a GPL-3.0 `LICENSE` (see below), `.clang-format`, `.clang-tidy`, and the CI workflow.

## Review notes

**Why a new `LICENSE` file.**
`COPYING` is a 28-line authorship-and-notice file with no license body.
Renaming it satisfies neither GPLv3's requirement to convey a copy of the license
nor GitHub's license detection, which matches text rather than notices.
`COPYING` is untouched and keeps the 2012 authorship block.

**No Qt in CI yet.**
Nothing in this PR links Qt,
so installing it would add minutes per run and prove nothing.
The Qt legs arrive with the application target in PR 3.

**LLVM tools pinned to 22.1.8 from PyPI.**
Version skew between a contributor's clang-format and CI's
is the usual cause of phantom lint failures.
`pip install clang-format==22.1.8 clang-tidy==22.1.8` reproduces the CI result exactly.

**The last commit is review fallout.**
`Board::pieceAt` and `setPiece` subscripted a 64-entry array with `index(Square::None)`, which is `-1` —
an out-of-bounds read, and an out-of-bounds *write*.
`Square::None` is not exotic:
`makeSquare` returns it for a coordinate off the board,
`kingSquare` when a side has no king,
and `enPassantTarget` holds it most of the time.
Both accessors now assert, and a sanitizer CI job backs the assert up,
since the `ci` preset is RelWithDebInfo and so defines `NDEBUG`.
That job found a genuine use-after-scope in PR 2 on its first run.

Same commit: FEN split fields on spaces and tabs only,
so any record with a trailing newline was rejected —
which is every record read from a file, an `.epd` suite, or the clipboard.
And `serialise` could emit a record its own `parse` refuses.

## Verification

```
cmake --preset dev && cmake --build --preset dev && ctest --preset dev
```

- 58 tests pass.
- Builds warning-free under `-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Werror`.
- `clang-format --dry-run --Werror` and `clang-tidy` both clean.
- Passes under address and undefined-behaviour sanitizers.
- Verified from a fresh clone, not just an incremental build.

## Needs you

The coverage job reads a `CODECOV_TOKEN` repository secret.
Without it that job reports nothing and does **not** fail the run,
so CI is green either way — add it whenever convenient, or say the word and I will drop the job.
