### PR TITLE
Full FIDE rules, verified by perft (2/6)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,12 +19,15 @@ Checks: >
   -readability-identifier-length,
   -readability-magic-numbers,
   -misc-include-cleaner,
-  -modernize-use-designated-initializers
+  -modernize-use-designated-initializers,
+  -misc-no-recursion
 
 # misc-include-cleaner is an include-what-you-use pass. It wants every .cpp to
 # re-include what its own header already provides, which is churn without
 # safety here. modernize-use-designated-initializers is off because Piece's two
 # members have distinct types, so a positional swap will not compile anyway.
+# misc-no-recursion is off because perft walks a game tree, where recursion is
+# the shape of the problem rather than a mistake.
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'src/core/include/chess/.*\.hpp$'

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,6 +4,11 @@ add_library(chesscore STATIC
   src/Position.cpp
   src/Move.cpp
   src/Fen.cpp
+  src/Rules.cpp
+  src/MoveGenerator.cpp
+  src/San.cpp
+  src/Game.cpp
+  src/Pgn.cpp
 )
 
 add_library(cines::core ALIAS chesscore)

--- a/src/core/include/chess/Game.hpp
+++ b/src/core/include/chess/Game.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "chess/Move.hpp"
+#include "chess/MoveGenerator.hpp"
+#include "chess/Position.hpp"
+#include "chess/Rules.hpp"
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace chess {
+
+// A move as it was played, kept with the notation it was written in at the
+// time. Recomputing the notation later would need the position it was played
+// from, so it is recorded once, when that position is at hand.
+struct PlayedMove {
+    Move move;
+    std::string san;
+};
+
+// A game in progress: a starting position, the moves played from it, and where
+// in that sequence the viewer currently is.
+//
+// Every position along the way is kept rather than recomputed, which is what
+// makes undo, redo and jumping to an arbitrary ply all the same operation, and
+// what lets threefold repetition be answered by looking rather than guessing.
+// A long game is a few hundred positions of eighty bytes; the memory is not
+// worth optimising away.
+class Game {
+public:
+    Game();
+    explicit Game(const Position& start);
+
+    // Discards all history and starts again from the given position.
+    void reset(const Position& start = Position::starting());
+
+    [[nodiscard]] const Position& position() const { return positions_[currentPly_]; }
+    [[nodiscard]] const Position& startPosition() const { return positions_.front(); }
+    [[nodiscard]] Color sideToMove() const { return position().sideToMove; }
+
+    [[nodiscard]] MoveList legalMoves() const { return generateLegalMoves(position()); }
+
+    // Plays a move from the current position. Returns false, changing nothing,
+    // when the move is not legal here.
+    //
+    // Playing while rewound discards the moves that came after, which is what
+    // taking a different line means.
+    bool play(const Move& move);
+
+    // Convenience entry points for the same thing. playFrom is what a click on
+    // a board calls: it looks the squares up in the legal move list, so the
+    // caller never has to know whether the click meant a castle or an en
+    // passant capture.
+    bool playFrom(Square from, Square to, PieceType promotion = PieceType::None);
+    bool playSan(std::string_view text);
+    bool playUci(std::string_view text);
+
+    [[nodiscard]] bool canUndo() const { return currentPly_ > 0; }
+    [[nodiscard]] bool canRedo() const { return currentPly_ < moves_.size(); }
+    bool undo();
+    bool redo();
+
+    // Moves the viewer to a ply without discarding anything, which is what
+    // clicking an entry in the move list does. Ply 0 is the starting position.
+    bool goToPly(std::size_t ply);
+
+    [[nodiscard]] std::size_t currentPly() const { return currentPly_; }
+    [[nodiscard]] const std::vector<PlayedMove>& history() const { return moves_; }
+
+    // The move that led to the current position, or nullptr at the start. The
+    // board uses this to highlight where the last piece came from.
+    [[nodiscard]] const PlayedMove* lastMove() const;
+
+    // How many times the current position has occurred in this game, counting
+    // the present occurrence. Three means a draw may be claimed.
+    [[nodiscard]] int repetitionCount() const;
+
+    // Why the game is over, including threefold repetition, which needs the
+    // history and so cannot be answered by Rules alone.
+    [[nodiscard]] TerminalReason terminalReason() const;
+    [[nodiscard]] Outcome outcome() const;
+    [[nodiscard]] bool isOver() const { return terminalReason() != TerminalReason::None; }
+
+    [[nodiscard]] std::string fen() const;
+
+private:
+    // A position stripped of what does not distinguish it for repetition
+    // purposes. See Game.cpp for why the en passant square needs care.
+    [[nodiscard]] static Position repetitionKeyFor(const Position& position);
+
+    std::vector<Position> positions_;
+    std::vector<Position> repetitionKeys_;
+    std::vector<PlayedMove> moves_;
+    std::size_t currentPly_ = 0;
+};
+
+} // namespace chess

--- a/src/core/include/chess/MoveGenerator.hpp
+++ b/src/core/include/chess/MoveGenerator.hpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
 namespace chess {
 
@@ -32,11 +33,17 @@ public:
     // Looks a move up by from, to and promotion. This is how the user
     // interface turns a click, which knows nothing about castling or en
     // passant, into a move that carries the right kind.
-    [[nodiscard]] const Move* find(Square from, Square to, PieceType promotion = PieceType::None) const;
+    //
+    // Returns the move by value rather than a pointer into this list. A Move
+    // is four bytes, and the obvious way to write the call is
+    // generateLegalMoves(position).find(...), where a returned pointer would
+    // dangle the moment the temporary list died.
+    [[nodiscard]] std::optional<Move> find(
+        Square from, Square to, PieceType promotion = PieceType::None) const;
 
     [[nodiscard]] bool contains(Square from, Square to, PieceType promotion = PieceType::None) const
     {
-        return find(from, to, promotion) != nullptr;
+        return find(from, to, promotion).has_value();
     }
 
 private:

--- a/src/core/include/chess/MoveGenerator.hpp
+++ b/src/core/include/chess/MoveGenerator.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "chess/Move.hpp"
+#include "chess/Position.hpp"
+#include "chess/Types.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace chess {
+
+// A fixed-capacity list of moves.
+//
+// The most moves any legal chess position offers is 218, so 256 can never
+// overflow. Using storage that cannot allocate keeps perft honest: the
+// measurement is of the rules, not of the allocator.
+class MoveList {
+public:
+    static constexpr std::size_t kCapacity = 256;
+
+    void push(Move move) { moves_[size_++] = move; }
+
+    [[nodiscard]] std::size_t size() const { return size_; }
+    [[nodiscard]] bool empty() const { return size_ == 0; }
+
+    [[nodiscard]] const Move& operator[](std::size_t i) const { return moves_[i]; }
+
+    [[nodiscard]] const Move* begin() const { return moves_.data(); }
+    [[nodiscard]] const Move* end() const { return moves_.data() + size_; }
+
+    // Looks a move up by from, to and promotion. This is how the user
+    // interface turns a click, which knows nothing about castling or en
+    // passant, into a move that carries the right kind.
+    [[nodiscard]] const Move* find(Square from, Square to, PieceType promotion = PieceType::None) const;
+
+    [[nodiscard]] bool contains(Square from, Square to, PieceType promotion = PieceType::None) const
+    {
+        return find(from, to, promotion) != nullptr;
+    }
+
+private:
+    std::array<Move, kCapacity> moves_{};
+    std::size_t size_ = 0;
+};
+
+// Every move the side to move may legally play. Empty means the game is over:
+// checkmate if the side to move is in check, stalemate otherwise.
+[[nodiscard]] MoveList generateLegalMoves(const Position& position);
+
+// Moves that obey the piece's movement rules but may leave the mover's own
+// king attacked. Exposed for testing the two stages apart; callers that want
+// to know what may be played want generateLegalMoves.
+[[nodiscard]] MoveList generatePseudoLegalMoves(const Position& position);
+
+// True when playing this pseudo-legal move would not leave the mover in check.
+[[nodiscard]] bool isLegal(const Position& position, const Move& move);
+
+// Counts leaf nodes of the legal move tree to the given depth. Depth 0 counts
+// the position itself as one node.
+//
+// This is the acceptance test for the whole rule set. The published counts are
+// exact, so a single wrong castling or en passant case shows up as a wrong
+// number rather than as a subtle misbehaviour years later.
+[[nodiscard]] std::uint64_t perft(const Position& position, int depth);
+
+} // namespace chess

--- a/src/core/include/chess/Pgn.hpp
+++ b/src/core/include/chess/Pgn.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "chess/Game.hpp"
+
+#include <string>
+
+// Portable Game Notation: the text form of a whole game, which is what
+// "copy game" puts on the clipboard and what other chess software reads.
+//
+// Export only. Reading arbitrary PGN means handling variations, comments and
+// numeric annotation glyphs, and nothing in this application needs that.
+namespace chess::pgn {
+
+// The seven tags the PGN standard requires, in the order it requires them.
+// The Result tag is not here because it is derived from the game rather than
+// chosen.
+struct Tags {
+    std::string event = "Casual game";
+    std::string site = "CINES";
+    std::string date = "????.??.??"; // PGN's own form for an unknown date
+    std::string round = "-";
+    std::string white = "White";
+    std::string black = "Black";
+};
+
+// The result token: "1-0", "0-1", "1/2-1/2", or "*" for a game still going.
+[[nodiscard]] std::string resultToken(const Game& game);
+
+// The whole game as PGN: the seven tag pairs, a blank line, then the movetext
+// wrapped at 80 columns as the standard asks.
+//
+// A game that did not start from the usual position also carries the SetUp and
+// FEN tags, without which the movetext cannot be replayed.
+[[nodiscard]] std::string serialise(const Game& game, const Tags& tags = {});
+
+} // namespace chess::pgn

--- a/src/core/include/chess/Position.hpp
+++ b/src/core/include/chess/Position.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "chess/Board.hpp"
+#include "chess/Move.hpp"
 #include "chess/Types.hpp"
 
 #include <cstdint>
@@ -83,5 +84,32 @@ struct Position {
 
     friend bool operator==(const Position& a, const Position& b);
 };
+
+// The squares a rook starts on, and so the squares whose occupant leaving or
+// being captured costs a castling right.
+[[nodiscard]] constexpr Square kingSideRookSquare(Color c)
+{
+    return c == Color::White ? Square::H1 : Square::H8;
+}
+
+[[nodiscard]] constexpr Square queenSideRookSquare(Color c)
+{
+    return c == Color::White ? Square::A1 : Square::A8;
+}
+
+[[nodiscard]] constexpr Square kingStartSquare(Color c)
+{
+    return c == Color::White ? Square::E1 : Square::E8;
+}
+
+// Applies a move and returns the resulting position. Pure: the input is not
+// modified, which is what lets the legality filter try a move and throw the
+// result away, and what lets Game keep a history by value.
+//
+// The move must carry the right MoveKind, which is what the generator
+// produces. Re-deriving "was that an en passant capture?" from the board here
+// would duplicate the generator's reasoning, and that duplication is where the
+// 2012 code went wrong.
+[[nodiscard]] Position applyMove(const Position& position, const Move& move);
 
 } // namespace chess

--- a/src/core/include/chess/Rules.hpp
+++ b/src/core/include/chess/Rules.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "chess/Board.hpp"
+#include "chess/Position.hpp"
+#include "chess/Types.hpp"
+
+namespace chess {
+
+// Why a game stopped. Ongoing means it has not.
+enum class TerminalReason : std::uint8_t {
+    None,
+    Checkmate,
+    Stalemate,
+    FiftyMoveRule,
+    ThreefoldRepetition,
+    InsufficientMaterial,
+};
+
+enum class Outcome : std::uint8_t { Ongoing, WhiteWins, BlackWins, Draw };
+
+// True when any piece of `attacker` could capture onto `square`, whether or
+// not doing so would be legal for the attacker. This is the primitive behind
+// check detection, castling restrictions and the legality filter.
+//
+// It works outwards from the square rather than iterating every enemy piece,
+// so the cost is a fixed handful of rays instead of a full board scan. That
+// matters: it is the innermost operation in perft.
+[[nodiscard]] bool isSquareAttacked(const Board& board, Square square, Color attacker);
+
+// True when `color`'s king stands on an attacked square. A position with no
+// king of that colour is not in check.
+[[nodiscard]] bool isInCheck(const Position& position, Color color);
+
+// True when the side to move is in check.
+[[nodiscard]] bool isInCheck(const Position& position);
+
+// Neither side has the material to force mate: king against king, king and a
+// single minor piece against king, or king and bishop against king and bishop
+// with both bishops on squares of the same colour.
+[[nodiscard]] bool hasInsufficientMaterial(const Position& position);
+
+// Why this position is terminal, considering only what a single position can
+// show. Threefold repetition needs the move history, so it is Game's job and
+// is never returned here.
+[[nodiscard]] TerminalReason terminalReason(const Position& position);
+
+// The result implied by a reason, given whose turn it is. Checkmate is a loss
+// for the side to move; every other terminal reason is a draw.
+[[nodiscard]] Outcome outcomeFor(TerminalReason reason, Color sideToMove);
+
+} // namespace chess

--- a/src/core/include/chess/San.hpp
+++ b/src/core/include/chess/San.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "chess/Move.hpp"
+#include "chess/Position.hpp"
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+// Standard Algebraic Notation: how moves are written for people, and the form
+// PGN records them in.
+//
+// A move only has a SAN spelling relative to a position. "Nf3" names a
+// different move on a different board, and whether it needs to be written
+// "Nbd2" depends on what else can reach d2. Both functions therefore take the
+// position the move is played from.
+namespace chess::san {
+
+// The move as it would be written: "e4", "exd5", "Nbd2", "O-O", "e8=Q+",
+// "Qxf7#". The check and mate suffixes are appended by playing the move, so
+// they are always right rather than guessed.
+//
+// The move must be legal in this position; the spelling of an illegal move is
+// not meaningful.
+[[nodiscard]] std::string toSan(const Position& position, const Move& move);
+
+// Reads a SAN move, returning the matching legal move with its kind filled in.
+//
+// This works by spelling every legal move and comparing, so anything toSan can
+// write, parse can read, and no separate grammar can drift out of step with
+// it. Check and mate suffixes are optional, annotation marks such as "!?" are
+// ignored, and castling may be written with zeroes.
+//
+// Returns nullopt when the text names no legal move.
+[[nodiscard]] std::optional<Move> parse(const Position& position, std::string_view text);
+
+} // namespace chess::san

--- a/src/core/src/Game.cpp
+++ b/src/core/src/Game.cpp
@@ -50,8 +50,11 @@ Position Game::repetitionKeyFor(const Position& position)
 
 bool Game::play(const Move& move)
 {
-    const Move* legal = legalMoves().find(move.from, move.to, move.promotion);
-    if (legal == nullptr) {
+    // Look the move up rather than trusting the caller's kind: a click on a
+    // board produces two squares and nothing more, and only the generator
+    // knows whether those squares mean a castle or an en passant capture.
+    const std::optional<Move> legal = legalMoves().find(move.from, move.to, move.promotion);
+    if (!legal) {
         return false;
     }
 
@@ -73,11 +76,9 @@ bool Game::play(const Move& move)
 
 bool Game::playFrom(Square from, Square to, PieceType promotion)
 {
-    const Move* legal = legalMoves().find(from, to, promotion);
-    if (legal == nullptr) {
-        return false;
-    }
-    return play(*legal);
+    // Move identity is from, to and promotion, so the placeholder kind here is
+    // replaced by the real one during the lookup in play.
+    return play(Move{from, to, promotion, MoveKind::Quiet});
 }
 
 bool Game::playSan(std::string_view text)

--- a/src/core/src/Game.cpp
+++ b/src/core/src/Game.cpp
@@ -1,0 +1,176 @@
+#include "chess/Game.hpp"
+
+#include "chess/Fen.hpp"
+#include "chess/San.hpp"
+
+namespace chess {
+
+Game::Game()
+    : Game(Position::starting())
+{
+}
+
+Game::Game(const Position& start)
+{
+    reset(start);
+}
+
+void Game::reset(const Position& start)
+{
+    positions_.assign(1, start);
+    repetitionKeys_.assign(1, repetitionKeyFor(start));
+    moves_.clear();
+    currentPly_ = 0;
+}
+
+// Two positions repeat only if the same moves are available in both. The en
+// passant square is the trap: a position where a double push just happened but
+// no pawn can answer it is, for repetition, the same as one where no push
+// happened at all. FEN records the square unconditionally, as most tools do,
+// so it is normalised away here instead.
+Position Game::repetitionKeyFor(const Position& position)
+{
+    Position key = position;
+
+    if (isValid(key.enPassantTarget)) {
+        bool captureAvailable = false;
+        for (const Move& move : generateLegalMoves(position)) {
+            if (move.kind == MoveKind::EnPassant) {
+                captureAvailable = true;
+                break;
+            }
+        }
+        if (!captureAvailable) {
+            key.enPassantTarget = Square::None;
+        }
+    }
+
+    return key;
+}
+
+bool Game::play(const Move& move)
+{
+    const Move* legal = legalMoves().find(move.from, move.to, move.promotion);
+    if (legal == nullptr) {
+        return false;
+    }
+
+    // Playing while rewound abandons the line that was there.
+    positions_.resize(currentPly_ + 1);
+    repetitionKeys_.resize(currentPly_ + 1);
+    moves_.resize(currentPly_);
+
+    const Position& before = positions_[currentPly_];
+    moves_.push_back(PlayedMove{*legal, san::toSan(before, *legal)});
+
+    const Position after = applyMove(before, *legal);
+    positions_.push_back(after);
+    repetitionKeys_.push_back(repetitionKeyFor(after));
+    ++currentPly_;
+
+    return true;
+}
+
+bool Game::playFrom(Square from, Square to, PieceType promotion)
+{
+    const Move* legal = legalMoves().find(from, to, promotion);
+    if (legal == nullptr) {
+        return false;
+    }
+    return play(*legal);
+}
+
+bool Game::playSan(std::string_view text)
+{
+    const auto move = san::parse(position(), text);
+    if (!move) {
+        return false;
+    }
+    return play(*move);
+}
+
+bool Game::playUci(std::string_view text)
+{
+    const auto move = Move::fromUci(text);
+    if (!move) {
+        return false;
+    }
+    return play(*move);
+}
+
+bool Game::undo()
+{
+    if (!canUndo()) {
+        return false;
+    }
+    --currentPly_;
+    return true;
+}
+
+bool Game::redo()
+{
+    if (!canRedo()) {
+        return false;
+    }
+    ++currentPly_;
+    return true;
+}
+
+bool Game::goToPly(std::size_t ply)
+{
+    if (ply >= positions_.size()) {
+        return false;
+    }
+    currentPly_ = ply;
+    return true;
+}
+
+const PlayedMove* Game::lastMove() const
+{
+    if (currentPly_ == 0) {
+        return nullptr;
+    }
+    return &moves_[currentPly_ - 1];
+}
+
+int Game::repetitionCount() const
+{
+    const Position& key = repetitionKeys_[currentPly_];
+
+    int count = 0;
+    // Only positions up to where the viewer stands count. Moves ahead in the
+    // history belong to a line that has not been played yet.
+    for (std::size_t ply = 0; ply <= currentPly_; ++ply) {
+        if (repetitionKeys_[ply].sameGameState(key)) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+TerminalReason Game::terminalReason() const
+{
+    // Checkmate and stalemate outrank the drawing rules: a game that ends in
+    // mate ended in mate, whatever the counters say.
+    const TerminalReason fromPosition = chess::terminalReason(position());
+    if (fromPosition == TerminalReason::Checkmate || fromPosition == TerminalReason::Stalemate) {
+        return fromPosition;
+    }
+
+    if (repetitionCount() >= 3) {
+        return TerminalReason::ThreefoldRepetition;
+    }
+    return fromPosition;
+}
+
+Outcome Game::outcome() const
+{
+    return outcomeFor(terminalReason(), sideToMove());
+}
+
+std::string Game::fen() const
+{
+    return fen::serialise(position());
+}
+
+} // namespace chess

--- a/src/core/src/Geometry.hpp
+++ b/src/core/src/Geometry.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "chess/Types.hpp"
+
+#include <array>
+#include <span>
+
+// Board geometry shared by move generation and attack detection.
+//
+// This table is what replaces the 2012 validation.cpp, where the same ray walk
+// was written out eight times for the queen, four more for the rook and four
+// more for the bishop. Describing the directions as data instead of as code
+// means a bug in the walk can only exist in one place.
+namespace chess::geometry {
+
+struct Offset {
+    int file;
+    int rank;
+};
+
+inline constexpr std::array<Offset, 4> kOrthogonal{{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}};
+
+inline constexpr std::array<Offset, 4> kDiagonal{{{1, 1}, {1, -1}, {-1, 1}, {-1, -1}}};
+
+inline constexpr std::array<Offset, 8> kAllDirections{
+    {{1, 0}, {-1, 0}, {0, 1}, {0, -1}, {1, 1}, {1, -1}, {-1, 1}, {-1, -1}}};
+
+inline constexpr std::array<Offset, 8> kKnightHops{
+    {{1, 2}, {2, 1}, {2, -1}, {1, -2}, {-1, -2}, {-2, -1}, {-2, 1}, {-1, 2}}};
+
+// How a piece travels: which directions, and whether it slides along them or
+// takes exactly one step. Pawns are absent because they are the one piece
+// whose captures and non-captures differ, so they get their own generator.
+struct Movement {
+    std::span<const Offset> directions;
+    bool sliding;
+};
+
+[[nodiscard]] constexpr Movement movementFor(PieceType type)
+{
+    switch (type) {
+    case PieceType::Rook:
+        return {kOrthogonal, true};
+    case PieceType::Bishop:
+        return {kDiagonal, true};
+    case PieceType::Queen:
+        return {kAllDirections, true};
+    case PieceType::King:
+        return {kAllDirections, false};
+    case PieceType::Knight:
+        return {kKnightHops, false};
+    case PieceType::Pawn:
+    case PieceType::None:
+        break;
+    }
+    return {{}, false};
+}
+
+// Steps off a square, yielding Square::None when the step leaves the board.
+// Guarding against an invalid input matters: fileOf(Square::None) is -1, and
+// adding an offset to that could otherwise land back on a real square.
+[[nodiscard]] constexpr Square offsetFrom(Square square, Offset offset)
+{
+    if (!isValid(square)) {
+        return Square::None;
+    }
+    return makeSquare(
+        static_cast<int>(fileOf(square)) + offset.file, static_cast<int>(rankOf(square)) + offset.rank);
+}
+
+// Light or dark square, which is what decides whether two bishops can ever
+// meet and so whether a bishop endgame is a dead draw.
+[[nodiscard]] constexpr bool isLightSquare(Square square)
+{
+    return ((static_cast<int>(fileOf(square)) + static_cast<int>(rankOf(square))) % 2) != 0;
+}
+
+} // namespace chess::geometry

--- a/src/core/src/MoveGenerator.cpp
+++ b/src/core/src/MoveGenerator.cpp
@@ -1,0 +1,230 @@
+#include "chess/MoveGenerator.hpp"
+
+#include "Geometry.hpp"
+#include "chess/Rules.hpp"
+
+namespace chess {
+namespace {
+
+using geometry::Offset;
+
+constexpr std::array<PieceType, 4> kPromotionChoices{
+    PieceType::Queen, PieceType::Rook, PieceType::Bishop, PieceType::Knight};
+
+// Adds a pawn move, expanding it into the four promotion choices when it lands
+// on the far rank. Every pawn move goes through here so that no path can
+// forget that a pawn reaching the eighth rank must become something.
+void addPawnMove(MoveList& moves, Color mover, Square from, Square to, MoveKind kind)
+{
+    if (rankOf(to) != promotionRank(mover)) {
+        moves.push(Move{from, to, PieceType::None, kind});
+        return;
+    }
+    for (const PieceType promotion : kPromotionChoices) {
+        moves.push(Move{from, to, promotion, kind});
+    }
+}
+
+void generatePawnMoves(const Position& position, Square from, MoveList& moves)
+{
+    const Board& board = position.board;
+    const Color mover = position.sideToMove;
+    const int step = pawnPush(mover);
+    const int file = static_cast<int>(fileOf(from));
+    const int rank = static_cast<int>(rankOf(from));
+
+    const Square oneForward = makeSquare(file, rank + step);
+    if (isValid(oneForward) && board.isEmpty(oneForward)) {
+        addPawnMove(moves, mover, from, oneForward, MoveKind::Quiet);
+
+        // The two-square opening is only available from the pawn's home rank,
+        // and only when both squares are clear -- a pawn does not jump.
+        if (rankOf(from) == pawnStartRank(mover)) {
+            const Square twoForward = makeSquare(file, rank + (2 * step));
+            if (isValid(twoForward) && board.isEmpty(twoForward)) {
+                moves.push(Move{from, twoForward, PieceType::None, MoveKind::DoublePawnPush});
+            }
+        }
+    }
+
+    for (const int fileStep : {-1, 1}) {
+        const Square target = makeSquare(file + fileStep, rank + step);
+        if (!isValid(target)) {
+            continue;
+        }
+        if (board.hasPieceOf(target, opposite(mover))) {
+            addPawnMove(moves, mover, from, target, MoveKind::Capture);
+        } else if (target == position.enPassantTarget) {
+            // The destination is empty; the pawn being taken is beside it.
+            moves.push(Move{from, target, PieceType::None, MoveKind::EnPassant});
+        }
+    }
+}
+
+void generateSteppingMoves(const Position& position, Square from, PieceType type, MoveList& moves)
+{
+    const Board& board = position.board;
+    const Color mover = position.sideToMove;
+    const geometry::Movement movement = geometry::movementFor(type);
+
+    for (const Offset direction : movement.directions) {
+        Square current = geometry::offsetFrom(from, direction);
+        while (isValid(current)) {
+            const Piece occupant = board.pieceAt(current);
+            if (occupant.isEmpty()) {
+                moves.push(Move{from, current, PieceType::None, MoveKind::Quiet});
+                if (!movement.sliding) {
+                    break;
+                }
+                current = geometry::offsetFrom(current, direction);
+                continue;
+            }
+            if (occupant.color != mover) {
+                moves.push(Move{from, current, PieceType::None, MoveKind::Capture});
+            }
+            // A piece of either colour ends the ray.
+            break;
+        }
+    }
+}
+
+// Castling has four conditions beyond the right still being held: the squares
+// between king and rook are empty, the rook is actually there, the king is not
+// in check, and it does not pass through an attacked square. The 2012 code
+// implemented none of them, because it had no castling at all.
+void generateCastles(const Position& position, MoveList& moves)
+{
+    const Color mover = position.sideToMove;
+    const Square kingFrom = kingStartSquare(mover);
+    const Color enemy = opposite(mover);
+    const Board& board = position.board;
+    const int backRank = mover == Color::White ? 0 : 7;
+
+    if (board.pieceAt(kingFrom) != Piece{PieceType::King, mover}) {
+        return;
+    }
+    if (isSquareAttacked(board, kingFrom, enemy)) {
+        return;
+    }
+
+    struct Side {
+        CastlingRights::Flag right;
+        Square rookSquare;
+        std::array<int, 3> mustBeEmptyFiles;
+        int emptyCount;
+        int crossedFile;
+        int kingDestinationFile;
+        MoveKind kind;
+    };
+
+    const std::array<Side, 2> sides{
+        Side{CastlingRights::kingSideFor(mover), kingSideRookSquare(mover), {5, 6, 0}, 2, 5, 6,
+            MoveKind::CastleKingSide},
+        // The b-file square must be empty for the rook to pass, but the king
+        // never stands on it, so it may be attacked.
+        Side{CastlingRights::queenSideFor(mover), queenSideRookSquare(mover), {1, 2, 3}, 3, 3, 2,
+            MoveKind::CastleQueenSide},
+    };
+
+    for (const Side& side : sides) {
+        if (!position.castling.has(side.right)) {
+            continue;
+        }
+        if (board.pieceAt(side.rookSquare) != Piece{PieceType::Rook, mover}) {
+            continue;
+        }
+
+        bool pathIsClear = true;
+        for (int i = 0; i < side.emptyCount; ++i) {
+            if (!board.isEmpty(makeSquare(side.mustBeEmptyFiles[static_cast<std::size_t>(i)], backRank))) {
+                pathIsClear = false;
+                break;
+            }
+        }
+        if (!pathIsClear) {
+            continue;
+        }
+
+        // The square the king crosses. Its destination is left to the general
+        // legality filter, which rejects any move ending in check.
+        if (isSquareAttacked(board, makeSquare(side.crossedFile, backRank), enemy)) {
+            continue;
+        }
+
+        moves.push(
+            Move{kingFrom, makeSquare(side.kingDestinationFile, backRank), PieceType::None, side.kind});
+    }
+}
+
+} // namespace
+
+const Move* MoveList::find(Square from, Square to, PieceType promotion) const
+{
+    for (const Move& move : *this) {
+        if (move.from == from && move.to == to && move.promotion == promotion) {
+            return &move;
+        }
+    }
+    return nullptr;
+}
+
+MoveList generatePseudoLegalMoves(const Position& position)
+{
+    MoveList moves;
+    const Color mover = position.sideToMove;
+
+    for (int i = 0; i < kSquareCount; ++i) {
+        const auto from = static_cast<Square>(i);
+        const Piece piece = position.board.pieceAt(from);
+        if (piece.isEmpty() || piece.color != mover) {
+            continue;
+        }
+
+        if (piece.type == PieceType::Pawn) {
+            generatePawnMoves(position, from, moves);
+        } else {
+            generateSteppingMoves(position, from, piece.type, moves);
+        }
+    }
+
+    generateCastles(position, moves);
+    return moves;
+}
+
+bool isLegal(const Position& position, const Move& move)
+{
+    const Color mover = position.sideToMove;
+    const Position next = applyMove(position, move);
+    return !isInCheck(next, mover);
+}
+
+MoveList generateLegalMoves(const Position& position)
+{
+    MoveList legal;
+    for (const Move& move : generatePseudoLegalMoves(position)) {
+        if (isLegal(position, move)) {
+            legal.push(move);
+        }
+    }
+    return legal;
+}
+
+std::uint64_t perft(const Position& position, int depth)
+{
+    if (depth <= 0) {
+        return 1;
+    }
+
+    const MoveList moves = generateLegalMoves(position);
+    if (depth == 1) {
+        return moves.size();
+    }
+
+    std::uint64_t nodes = 0;
+    for (const Move& move : moves) {
+        nodes += perft(applyMove(position, move), depth - 1);
+    }
+    return nodes;
+}
+
+} // namespace chess

--- a/src/core/src/MoveGenerator.cpp
+++ b/src/core/src/MoveGenerator.cpp
@@ -158,14 +158,14 @@ void generateCastles(const Position& position, MoveList& moves)
 
 } // namespace
 
-const Move* MoveList::find(Square from, Square to, PieceType promotion) const
+std::optional<Move> MoveList::find(Square from, Square to, PieceType promotion) const
 {
     for (const Move& move : *this) {
         if (move.from == from && move.to == to && move.promotion == promotion) {
-            return &move;
+            return move;
         }
     }
-    return nullptr;
+    return std::nullopt;
 }
 
 MoveList generatePseudoLegalMoves(const Position& position)

--- a/src/core/src/Pgn.cpp
+++ b/src/core/src/Pgn.cpp
@@ -1,0 +1,102 @@
+#include "chess/Pgn.hpp"
+
+#include "chess/Fen.hpp"
+
+#include <string>
+
+namespace chess::pgn {
+namespace {
+
+constexpr std::size_t kMaxLineLength = 80;
+
+std::string tagPair(std::string_view name, std::string_view value)
+{
+    return "[" + std::string(name) + " \"" + std::string(value) + "\"]\n";
+}
+
+// Appends a token, breaking the line first when it would otherwise run past
+// the standard's 80 column limit. Tokens are never split.
+void appendToken(std::string& text, std::size_t& lineLength, const std::string& token)
+{
+    if (lineLength > 0 && lineLength + 1 + token.size() > kMaxLineLength) {
+        text += '\n';
+        lineLength = 0;
+    } else if (lineLength > 0) {
+        text += ' ';
+        ++lineLength;
+    }
+    text += token;
+    lineLength += token.size();
+}
+
+} // namespace
+
+std::string resultToken(const Game& game)
+{
+    switch (game.outcome()) {
+    case Outcome::WhiteWins:
+        return "1-0";
+    case Outcome::BlackWins:
+        return "0-1";
+    case Outcome::Draw:
+        return "1/2-1/2";
+    case Outcome::Ongoing:
+        break;
+    }
+    return "*";
+}
+
+std::string serialise(const Game& game, const Tags& tags)
+{
+    const std::string result = resultToken(game);
+    const Position& start = game.startPosition();
+    const bool fromCustomPosition = !(start == Position::starting());
+
+    std::string text;
+    text += tagPair("Event", tags.event);
+    text += tagPair("Site", tags.site);
+    text += tagPair("Date", tags.date);
+    text += tagPair("Round", tags.round);
+    text += tagPair("White", tags.white);
+    text += tagPair("Black", tags.black);
+    text += tagPair("Result", result);
+
+    // Without these two, a game that did not start from the usual position
+    // cannot be replayed from its movetext.
+    if (fromCustomPosition) {
+        text += tagPair("SetUp", "1");
+        text += tagPair("FEN", fen::serialise(start));
+    }
+
+    text += '\n';
+
+    // Move numbers follow the starting position, so a game set up with Black
+    // to move opens "12... Nf6" rather than "1. Nf6".
+    int moveNumber = start.fullmoveNumber;
+    bool whiteToMove = start.sideToMove == Color::White;
+    std::size_t lineLength = 0;
+
+    for (const PlayedMove& played : game.history()) {
+        if (whiteToMove) {
+            appendToken(text, lineLength, std::to_string(moveNumber) + ".");
+        } else if (lineLength == 0) {
+            // Black's move opening a line needs the number repeated, or the
+            // reader cannot tell which move it is.
+            appendToken(text, lineLength, std::to_string(moveNumber) + "...");
+        }
+
+        appendToken(text, lineLength, played.san);
+
+        if (!whiteToMove) {
+            ++moveNumber;
+        }
+        whiteToMove = !whiteToMove;
+    }
+
+    appendToken(text, lineLength, result);
+    text += '\n';
+
+    return text;
+}
+
+} // namespace chess::pgn

--- a/src/core/src/Position.cpp
+++ b/src/core/src/Position.cpp
@@ -25,4 +25,89 @@ bool operator==(const Position& a, const Position& b)
     return a.sameGameState(b) && a.halfmoveClock == b.halfmoveClock && a.fullmoveNumber == b.fullmoveNumber;
 }
 
+namespace {
+
+// A castling right is lost when the king moves, when its rook moves, or when
+// that rook is captured where it stands. The last case is the one that is easy
+// to forget: capturing a rook on h8 ends Black's king-side castling even
+// though Black never moved anything.
+void revokeRightsTouching(CastlingRights& rights, Square square)
+{
+    for (const Color color : {Color::White, Color::Black}) {
+        if (square == kingStartSquare(color)) {
+            rights.remove(CastlingRights::kingSideFor(color));
+            rights.remove(CastlingRights::queenSideFor(color));
+        }
+        if (square == kingSideRookSquare(color)) {
+            rights.remove(CastlingRights::kingSideFor(color));
+        }
+        if (square == queenSideRookSquare(color)) {
+            rights.remove(CastlingRights::queenSideFor(color));
+        }
+    }
+}
+
+// The rook's own from and to squares for a castle, given where the king lands.
+struct RookTravel {
+    Square from;
+    Square to;
+};
+
+RookTravel rookTravelFor(Color mover, MoveKind kind)
+{
+    const int backRank = mover == Color::White ? 0 : 7;
+    if (kind == MoveKind::CastleKingSide) {
+        return {makeSquare(7, backRank), makeSquare(5, backRank)};
+    }
+    return {makeSquare(0, backRank), makeSquare(3, backRank)};
+}
+
+} // namespace
+
+Position applyMove(const Position& position, const Move& move)
+{
+    Position next = position;
+
+    const Piece mover = position.board.pieceAt(move.from);
+    const bool isPawnMove = mover.type == PieceType::Pawn;
+
+    // A capture or a pawn move resets the fifty-move counter. Everything else
+    // advances it, which is what eventually forces a draw in a dead position.
+    next.halfmoveClock = (isPawnMove || move.isCapture()) ? 0 : position.halfmoveClock + 1;
+
+    next.board.clearSquare(move.from);
+
+    if (move.kind == MoveKind::EnPassant) {
+        // The captured pawn is beside the destination, not on it.
+        const Square captured
+            = makeSquare(static_cast<int>(fileOf(move.to)), static_cast<int>(rankOf(move.from)));
+        next.board.clearSquare(captured);
+    }
+
+    next.board.setPiece(move.to, move.isPromotion() ? Piece{move.promotion, mover.color} : mover);
+
+    if (move.isCastle()) {
+        const RookTravel rook = rookTravelFor(mover.color, move.kind);
+        const Piece rookPiece = next.board.pieceAt(rook.from);
+        next.board.clearSquare(rook.from);
+        next.board.setPiece(rook.to, rookPiece);
+    }
+
+    revokeRightsTouching(next.castling, move.from);
+    revokeRightsTouching(next.castling, move.to);
+
+    next.enPassantTarget = Square::None;
+    if (move.kind == MoveKind::DoublePawnPush) {
+        const int skipped = (static_cast<int>(rankOf(move.from)) + static_cast<int>(rankOf(move.to))) / 2;
+        next.enPassantTarget = makeSquare(static_cast<int>(fileOf(move.from)), skipped);
+    }
+
+    if (position.sideToMove == Color::Black) {
+        ++next.fullmoveNumber;
+    }
+    next.sideToMove = opposite(position.sideToMove);
+
+    return next;
+}
+
 } // namespace chess

--- a/src/core/src/Rules.cpp
+++ b/src/core/src/Rules.cpp
@@ -1,0 +1,200 @@
+#include "chess/Rules.hpp"
+
+#include "Geometry.hpp"
+#include "chess/MoveGenerator.hpp"
+
+#include <algorithm>
+
+namespace chess {
+namespace {
+
+using geometry::Offset;
+
+// Walks outwards along `directions` looking for an enemy slider that could
+// reach the origin. The first piece met in each direction blocks the rest of
+// that ray, whichever side it belongs to.
+bool isAttackedBySlider(
+    const Board& board, Square origin, Color attacker, std::span<const Offset> directions, PieceType slider)
+{
+    for (const Offset direction : directions) {
+        Square current = geometry::offsetFrom(origin, direction);
+        while (isValid(current)) {
+            const Piece piece = board.pieceAt(current);
+            if (!piece.isEmpty()) {
+                if (piece.color == attacker && (piece.type == slider || piece.type == PieceType::Queen)) {
+                    return true;
+                }
+                break;
+            }
+            current = geometry::offsetFrom(current, direction);
+        }
+    }
+    return false;
+}
+
+bool isAttackedByHopper(
+    const Board& board, Square origin, Color attacker, std::span<const Offset> hops, PieceType hopper)
+{
+    return std::ranges::any_of(hops, [&](const Offset hop) {
+        const Square candidate = geometry::offsetFrom(origin, hop);
+        return isValid(candidate) && board.pieceAt(candidate) == Piece{hopper, attacker};
+    });
+}
+
+// A White pawn on rank r attacks rank r+1, so a White pawn attacking `origin`
+// stands one rank behind it. Working backwards like this costs two square
+// lookups instead of a scan for every enemy pawn.
+bool isAttackedByPawn(const Board& board, Square origin, Color attacker)
+{
+    const int sourceRank = static_cast<int>(rankOf(origin)) - pawnPush(attacker);
+    const int originFile = static_cast<int>(fileOf(origin));
+
+    for (const int fileStep : {-1, 1}) {
+        const Square candidate = makeSquare(originFile + fileStep, sourceRank);
+        if (isValid(candidate) && board.pieceAt(candidate) == Piece{PieceType::Pawn, attacker}) {
+            return true;
+        }
+    }
+    return false;
+}
+
+struct MaterialCount {
+    int pawns = 0;
+    int knights = 0;
+    int bishops = 0;
+    int rooks = 0;
+    int queens = 0;
+    int lightSquareBishops = 0;
+    int darkSquareBishops = 0;
+
+    [[nodiscard]] int minors() const { return knights + bishops; }
+    [[nodiscard]] bool hasMatingMaterialOnItsOwn() const { return pawns > 0 || rooks > 0 || queens > 0; }
+};
+
+MaterialCount countMaterial(const Board& board, Color color)
+{
+    MaterialCount count;
+    for (int i = 0; i < kSquareCount; ++i) {
+        const auto square = static_cast<Square>(i);
+        const Piece piece = board.pieceAt(square);
+        if (piece.isEmpty() || piece.color != color) {
+            continue;
+        }
+        switch (piece.type) {
+        case PieceType::Pawn:
+            ++count.pawns;
+            break;
+        case PieceType::Knight:
+            ++count.knights;
+            break;
+        case PieceType::Bishop:
+            ++count.bishops;
+            (geometry::isLightSquare(square) ? count.lightSquareBishops : count.darkSquareBishops)++;
+            break;
+        case PieceType::Rook:
+            ++count.rooks;
+            break;
+        case PieceType::Queen:
+            ++count.queens;
+            break;
+        case PieceType::King:
+        case PieceType::None:
+            break;
+        }
+    }
+    return count;
+}
+
+} // namespace
+
+bool isSquareAttacked(const Board& board, Square square, Color attacker)
+{
+    if (!isValid(square)) {
+        return false;
+    }
+
+    // Ordered cheapest and most likely first.
+    return isAttackedByPawn(board, square, attacker)
+        || isAttackedByHopper(board, square, attacker, geometry::kKnightHops, PieceType::Knight)
+        || isAttackedByHopper(board, square, attacker, geometry::kAllDirections, PieceType::King)
+        || isAttackedBySlider(board, square, attacker, geometry::kOrthogonal, PieceType::Rook)
+        || isAttackedBySlider(board, square, attacker, geometry::kDiagonal, PieceType::Bishop);
+}
+
+bool isInCheck(const Position& position, Color color)
+{
+    const Square king = position.board.kingSquare(color);
+    if (!isValid(king)) {
+        return false;
+    }
+    return isSquareAttacked(position.board, king, opposite(color));
+}
+
+bool isInCheck(const Position& position)
+{
+    return isInCheck(position, position.sideToMove);
+}
+
+bool hasInsufficientMaterial(const Position& position)
+{
+    const MaterialCount white = countMaterial(position.board, Color::White);
+    const MaterialCount black = countMaterial(position.board, Color::Black);
+
+    if (white.hasMatingMaterialOnItsOwn() || black.hasMatingMaterialOnItsOwn()) {
+        return false;
+    }
+
+    const int minors = white.minors() + black.minors();
+
+    // King against king, and king with one minor piece against king. Neither
+    // can be forced to mate.
+    if (minors <= 1) {
+        return true;
+    }
+
+    // King and bishop against king and bishop, both bishops on the same colour
+    // of square: they can never attack the same squares, so mate is impossible.
+    if (minors == 2 && white.bishops == 1 && black.bishops == 1) {
+        const bool bothLight = white.lightSquareBishops == 1 && black.lightSquareBishops == 1;
+        const bool bothDark = white.darkSquareBishops == 1 && black.darkSquareBishops == 1;
+        return bothLight || bothDark;
+    }
+
+    // Two knights against a lone king cannot force mate, but mate is still
+    // reachable if the defender helps, so it is not a dead position.
+    return false;
+}
+
+TerminalReason terminalReason(const Position& position)
+{
+    // Having no legal move is checked first: a mate delivered on the hundredth
+    // ply ends the game as a mate, not as a fifty-move draw.
+    if (generateLegalMoves(position).empty()) {
+        return isInCheck(position) ? TerminalReason::Checkmate : TerminalReason::Stalemate;
+    }
+    if (hasInsufficientMaterial(position)) {
+        return TerminalReason::InsufficientMaterial;
+    }
+    if (position.halfmoveClock >= 100) {
+        return TerminalReason::FiftyMoveRule;
+    }
+    return TerminalReason::None;
+}
+
+Outcome outcomeFor(TerminalReason reason, Color sideToMove)
+{
+    switch (reason) {
+    case TerminalReason::None:
+        return Outcome::Ongoing;
+    case TerminalReason::Checkmate:
+        return sideToMove == Color::White ? Outcome::BlackWins : Outcome::WhiteWins;
+    case TerminalReason::Stalemate:
+    case TerminalReason::FiftyMoveRule:
+    case TerminalReason::ThreefoldRepetition:
+    case TerminalReason::InsufficientMaterial:
+        return Outcome::Draw;
+    }
+    return Outcome::Ongoing;
+}
+
+} // namespace chess

--- a/src/core/src/San.cpp
+++ b/src/core/src/San.cpp
@@ -1,0 +1,155 @@
+#include "chess/San.hpp"
+
+#include "chess/MoveGenerator.hpp"
+#include "chess/Rules.hpp"
+
+#include <cctype>
+
+namespace chess::san {
+namespace {
+
+char fileLetter(Square square)
+{
+    return static_cast<char>('a' + static_cast<int>(fileOf(square)));
+}
+
+char rankDigit(Square square)
+{
+    return static_cast<char>('1' + static_cast<int>(rankOf(square)));
+}
+
+// What must be written between the piece letter and the destination so the
+// move is unambiguous: nothing, the file, the rank, or both.
+//
+// Both is needed only when three or more of the same piece can reach the
+// square, which happens with promoted pieces. Handling it costs one extra
+// branch and saves a wrong record later.
+std::string disambiguation(const Position& position, const Move& move, PieceType type)
+{
+    bool anyRival = false;
+    bool rivalOnSameFile = false;
+    bool rivalOnSameRank = false;
+
+    for (const Move& other : generateLegalMoves(position)) {
+        if (other.from == move.from || other.to != move.to) {
+            continue;
+        }
+        if (position.board.pieceAt(other.from).type != type) {
+            continue;
+        }
+        anyRival = true;
+        rivalOnSameFile = rivalOnSameFile || fileOf(other.from) == fileOf(move.from);
+        rivalOnSameRank = rivalOnSameRank || rankOf(other.from) == rankOf(move.from);
+    }
+
+    std::string hint;
+    if (!anyRival) {
+        return hint;
+    }
+
+    // The file alone when no rival shares it, the rank alone when no rival
+    // shares that, and both when rivals share each.
+    if (rivalOnSameFile && rivalOnSameRank) {
+        hint += fileLetter(move.from);
+        hint += rankDigit(move.from);
+    } else if (rivalOnSameFile) {
+        hint += rankDigit(move.from);
+    } else {
+        hint += fileLetter(move.from);
+    }
+    return hint;
+}
+
+// Strips what does not identify the move: check and mate marks, annotation
+// glyphs such as "!?", the optional "e.p." after an en passant capture, and
+// any stray whitespace. Zeroes in castling become the letter O.
+std::string normalise(std::string_view text)
+{
+    std::string cleaned;
+    cleaned.reserve(text.size());
+
+    for (const char c : text) {
+        switch (c) {
+        case '+':
+        case '#':
+        case '!':
+        case '?':
+        case ' ':
+        case '\t':
+        case '.':
+            continue;
+        case '0':
+            cleaned += 'O';
+            continue;
+        default:
+            cleaned += c;
+        }
+    }
+
+    // "exd6e.p." has lost its dots by now and reads "exd6ep".
+    if (cleaned.size() > 2 && cleaned.ends_with("ep")) {
+        cleaned.erase(cleaned.size() - 2);
+    }
+    return cleaned;
+}
+
+} // namespace
+
+std::string toSan(const Position& position, const Move& move)
+{
+    std::string text;
+
+    if (move.kind == MoveKind::CastleKingSide) {
+        text = "O-O";
+    } else if (move.kind == MoveKind::CastleQueenSide) {
+        text = "O-O-O";
+    } else {
+        const Piece piece = position.board.pieceAt(move.from);
+
+        if (piece.type == PieceType::Pawn) {
+            // A pawn capture always names its starting file, ambiguous or not.
+            if (move.isCapture()) {
+                text += fileLetter(move.from);
+                text += 'x';
+            }
+            text += toString(move.to);
+            if (move.isPromotion()) {
+                text += '=';
+                text += toChar(move.promotion);
+            }
+        } else {
+            text += toChar(piece.type);
+            text += disambiguation(position, move, piece.type);
+            if (move.isCapture()) {
+                text += 'x';
+            }
+            text += toString(move.to);
+        }
+    }
+
+    // Playing the move is the only way to be sure about check and mate, and it
+    // costs one move generation on a path that is not hot.
+    const Position after = applyMove(position, move);
+    if (isInCheck(after)) {
+        text += generateLegalMoves(after).empty() ? '#' : '+';
+    }
+
+    return text;
+}
+
+std::optional<Move> parse(const Position& position, std::string_view text)
+{
+    const std::string wanted = normalise(text);
+    if (wanted.empty()) {
+        return std::nullopt;
+    }
+
+    for (const Move& move : generateLegalMoves(position)) {
+        if (normalise(toSan(position, move)) == wanted) {
+            return move;
+        }
+    }
+    return std::nullopt;
+}
+
+} // namespace chess::san

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,3 +28,14 @@ cines_add_core_test(core_types_test types_test.cpp)
 cines_add_core_test(core_board_test board_test.cpp)
 cines_add_core_test(core_move_test move_test.cpp)
 cines_add_core_test(core_fen_test fen_test.cpp)
+cines_add_core_test(core_movegen_test movegen_test.cpp)
+cines_add_core_test(core_rules_test rules_test.cpp)
+cines_add_core_test(core_san_test san_test.cpp)
+cines_add_core_test(core_game_test game_test.cpp)
+cines_add_core_test(core_perft_test perft_test.cpp)
+
+# Perft is the acceptance test for the rules, so its deep levels are opt-in
+# rather than deleted: -DCINES_SLOW_TESTS=ON adds the levels that take minutes.
+if(CINES_SLOW_TESTS)
+  target_compile_definitions(core_perft_test PRIVATE CINES_SLOW_TESTS)
+endif()

--- a/tests/game_test.cpp
+++ b/tests/game_test.cpp
@@ -1,0 +1,298 @@
+#include "chess/Fen.hpp"
+#include "chess/Game.hpp"
+#include "chess/Pgn.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace chess {
+namespace {
+
+Position mustParse(std::string_view text)
+{
+    fen::ParseResult result = fen::parse(text);
+    if (const auto* failure = std::get_if<fen::ParseError>(&result)) {
+        ADD_FAILURE() << "expected '" << text << "' to parse, got: " << failure->message;
+        return Position{};
+    }
+    return std::get<Position>(result);
+}
+
+void playAll(Game& game, const std::vector<std::string>& moves)
+{
+    for (const std::string& move : moves) {
+        ASSERT_TRUE(game.playSan(move)) << "could not play " << move << " in " << game.fen();
+    }
+}
+
+TEST(Game, StartsFromTheUsualPosition)
+{
+    const Game game;
+    EXPECT_EQ(game.position(), Position::starting());
+    EXPECT_EQ(game.currentPly(), 0U);
+    EXPECT_TRUE(game.history().empty());
+    EXPECT_FALSE(game.canUndo());
+    EXPECT_FALSE(game.canRedo());
+    EXPECT_EQ(game.lastMove(), nullptr);
+}
+
+TEST(Game, PlayingRecordsTheMoveAndItsNotation)
+{
+    Game game;
+    ASSERT_TRUE(game.playSan("e4"));
+
+    ASSERT_EQ(game.history().size(), 1U);
+    EXPECT_EQ(game.history()[0].san, "e4");
+    EXPECT_EQ(game.history()[0].move.toUci(), "e2e4");
+    EXPECT_EQ(game.sideToMove(), Color::Black);
+    ASSERT_NE(game.lastMove(), nullptr);
+    EXPECT_EQ(game.lastMove()->move.from, Square::E2);
+}
+
+TEST(Game, RejectsAnIllegalMoveWithoutChangingAnything)
+{
+    Game game;
+    EXPECT_FALSE(game.playSan("e5"));
+    EXPECT_FALSE(game.playUci("e2e5"));
+    EXPECT_FALSE(game.playFrom(Square::E2, Square::E5));
+    EXPECT_EQ(game.position(), Position::starting());
+    EXPECT_TRUE(game.history().empty());
+}
+
+// A click on a board knows two squares and nothing about castling. playFrom is
+// what turns that into a move carrying the right kind.
+TEST(Game, PlayFromResolvesTheMoveKindForTheCaller)
+{
+    Game game(mustParse("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1"));
+    ASSERT_TRUE(game.playFrom(Square::E1, Square::G1));
+
+    EXPECT_EQ(game.history()[0].san, "O-O");
+    EXPECT_EQ(game.position().board.pieceAt(Square::F1), (Piece{PieceType::Rook, Color::White}));
+}
+
+TEST(Game, PlayFromNeedsThePromotionPieceNamed)
+{
+    Game game(mustParse("8/4P3/8/8/8/8/8/K6k w - - 0 1"));
+    EXPECT_FALSE(game.playFrom(Square::E7, Square::E8));
+    ASSERT_TRUE(game.playFrom(Square::E7, Square::E8, PieceType::Knight));
+    EXPECT_EQ(game.position().board.pieceAt(Square::E8), (Piece{PieceType::Knight, Color::White}));
+}
+
+TEST(Game, UndoAndRedoWalkTheHistoryWithoutLosingIt)
+{
+    Game game;
+    playAll(game, {"e4", "e5", "Nf3"});
+    ASSERT_EQ(game.currentPly(), 3U);
+
+    ASSERT_TRUE(game.undo());
+    EXPECT_EQ(game.currentPly(), 2U);
+    EXPECT_EQ(game.sideToMove(), Color::White);
+    EXPECT_EQ(game.history().size(), 3U) << "undo rewinds, it does not delete";
+
+    ASSERT_TRUE(game.undo());
+    ASSERT_TRUE(game.undo());
+    EXPECT_EQ(game.position(), Position::starting());
+    EXPECT_FALSE(game.canUndo());
+    EXPECT_FALSE(game.undo());
+
+    ASSERT_TRUE(game.redo());
+    ASSERT_TRUE(game.redo());
+    ASSERT_TRUE(game.redo());
+    EXPECT_EQ(game.currentPly(), 3U);
+    EXPECT_FALSE(game.canRedo());
+    EXPECT_FALSE(game.redo());
+}
+
+TEST(Game, PlayingAfterUndoDiscardsTheAbandonedLine)
+{
+    Game game;
+    playAll(game, {"e4", "e5", "Nf3"});
+    ASSERT_TRUE(game.undo());
+
+    ASSERT_TRUE(game.playSan("d4"));
+    EXPECT_EQ(game.history().size(), 3U);
+    EXPECT_EQ(game.history()[2].san, "d4");
+    EXPECT_FALSE(game.canRedo()) << "the discarded line is gone";
+}
+
+TEST(Game, GoToPlyMovesTheViewerWithoutDiscarding)
+{
+    Game game;
+    playAll(game, {"e4", "e5", "Nf3", "Nc6"});
+
+    ASSERT_TRUE(game.goToPly(1));
+    EXPECT_EQ(game.currentPly(), 1U);
+    EXPECT_EQ(game.history().size(), 4U);
+    EXPECT_TRUE(game.canRedo());
+
+    ASSERT_TRUE(game.goToPly(0));
+    EXPECT_EQ(game.position(), Position::starting());
+
+    ASSERT_TRUE(game.goToPly(4));
+    EXPECT_FALSE(game.goToPly(5)) << "there is no fifth ply";
+}
+
+TEST(Game, ResetClearsEverything)
+{
+    Game game;
+    playAll(game, {"e4", "e5"});
+    game.reset();
+
+    EXPECT_EQ(game.position(), Position::starting());
+    EXPECT_TRUE(game.history().empty());
+    EXPECT_EQ(game.currentPly(), 0U);
+    EXPECT_FALSE(game.canRedo());
+}
+
+TEST(Game, StartsFromACustomPositionWhenGivenOne)
+{
+    const Position start = mustParse("4k3/8/8/8/8/8/8/R3K3 w Q - 5 30");
+    Game game(start);
+    EXPECT_EQ(game.startPosition(), start);
+    EXPECT_EQ(game.fen(), fen::serialise(start));
+}
+
+TEST(Game, FoolsMateEndsTheGame)
+{
+    Game game;
+    playAll(game, {"f3", "e5", "g4", "Qh4"});
+
+    EXPECT_TRUE(game.isOver());
+    EXPECT_EQ(game.terminalReason(), TerminalReason::Checkmate);
+    EXPECT_EQ(game.outcome(), Outcome::BlackWins);
+    EXPECT_TRUE(game.legalMoves().empty());
+}
+
+TEST(Game, StalemateIsADraw)
+{
+    Game game(mustParse("7k/5Q2/8/8/8/8/8/6K1 w - - 0 1"));
+    ASSERT_TRUE(game.playSan("Kg2"));
+
+    EXPECT_EQ(game.terminalReason(), TerminalReason::Stalemate);
+    EXPECT_EQ(game.outcome(), Outcome::Draw);
+}
+
+// Knights shuffling back and forth reach the same position three times. This
+// is the rule the old code had no way to express, because it kept no history.
+TEST(Game, ThreefoldRepetitionIsDetected)
+{
+    Game game;
+    EXPECT_EQ(game.repetitionCount(), 1);
+
+    playAll(game, {"Nf3", "Nf6", "Ng1", "Ng8"});
+    EXPECT_EQ(game.repetitionCount(), 2);
+    EXPECT_FALSE(game.isOver());
+
+    playAll(game, {"Nf3", "Nf6", "Ng1", "Ng8"});
+    EXPECT_EQ(game.repetitionCount(), 3);
+    EXPECT_EQ(game.terminalReason(), TerminalReason::ThreefoldRepetition);
+    EXPECT_EQ(game.outcome(), Outcome::Draw);
+}
+
+TEST(Game, RepetitionCountFollowsTheViewerBackwards)
+{
+    Game game;
+    playAll(game, {"Nf3", "Nf6", "Ng1", "Ng8", "Nf3", "Nf6", "Ng1", "Ng8"});
+    EXPECT_EQ(game.repetitionCount(), 3);
+
+    // Rewinding to the second occurrence should count two, not three: the
+    // third has not been reached yet from where the viewer stands.
+    ASSERT_TRUE(game.goToPly(4));
+    EXPECT_EQ(game.repetitionCount(), 2);
+}
+
+// A double pawn push with no pawn able to answer it leaves an en passant
+// square that changes nothing. Two such positions repeat, even though their
+// FEN differs.
+TEST(Game, RepetitionIgnoresAnEnPassantSquareNobodyCanUse)
+{
+    Game game;
+    playAll(game, {"e4", "Nf6", "Nf3", "Ng8", "Ng1", "Nf6", "Nf3", "Ng8", "Ng1"});
+
+    // The position after 1.e4 recurs; the en passant square recorded then was
+    // never usable, so it must not keep the positions apart.
+    EXPECT_EQ(game.repetitionCount(), 3);
+    EXPECT_EQ(game.terminalReason(), TerminalReason::ThreefoldRepetition);
+}
+
+TEST(Game, CheckmateOutranksThreefoldRepetition)
+{
+    Game game(mustParse("6k1/5ppp/8/8/8/8/8/R5K1 w - - 0 1"));
+    ASSERT_TRUE(game.playSan("Ra8#"));
+    EXPECT_EQ(game.terminalReason(), TerminalReason::Checkmate);
+}
+
+TEST(Pgn, WritesTheSevenRequiredTagsAndTheMovetext)
+{
+    Game game;
+    playAll(game, {"e4", "e5", "Nf3", "Nc6"});
+
+    const std::string text = pgn::serialise(game, pgn::Tags{"Test", "Nowhere", "2026.08.12", "1", "A", "B"});
+
+    EXPECT_NE(text.find("[Event \"Test\"]"), std::string::npos);
+    EXPECT_NE(text.find("[White \"A\"]"), std::string::npos);
+    EXPECT_NE(text.find("[Black \"B\"]"), std::string::npos);
+    EXPECT_NE(text.find("[Result \"*\"]"), std::string::npos);
+    EXPECT_NE(text.find("1. e4 e5 2. Nf3 Nc6 *"), std::string::npos);
+    EXPECT_EQ(text.find("[FEN"), std::string::npos) << "no FEN tag for a normal start";
+}
+
+TEST(Pgn, RecordsTheResultOfAFinishedGame)
+{
+    Game game;
+    playAll(game, {"f3", "e5", "g4", "Qh4"});
+
+    const std::string text = pgn::serialise(game);
+    EXPECT_EQ(pgn::resultToken(game), "0-1");
+    EXPECT_NE(text.find("[Result \"0-1\"]"), std::string::npos);
+    EXPECT_NE(text.find("Qh4# 0-1"), std::string::npos);
+}
+
+// Without SetUp and FEN, the movetext of a game that did not start from the
+// usual position cannot be replayed.
+TEST(Pgn, CarriesSetUpAndFenForACustomStart)
+{
+    const Position start = mustParse("4k3/8/8/8/8/8/8/R3K3 w Q - 5 30");
+    Game game(start);
+    ASSERT_TRUE(game.playSan("Ra8+"));
+
+    const std::string text = pgn::serialise(game);
+    EXPECT_NE(text.find("[SetUp \"1\"]"), std::string::npos);
+    EXPECT_NE(text.find("[FEN \"" + fen::serialise(start) + "\"]"), std::string::npos);
+    EXPECT_NE(text.find("30. Ra8+"), std::string::npos) << "numbering follows the starting position";
+}
+
+TEST(Pgn, NumbersABlackFirstMoveWithAnEllipsis)
+{
+    const Position start = mustParse("4k3/8/8/8/8/8/8/R3K3 b Q - 5 30");
+    Game game(start);
+    ASSERT_TRUE(game.playSan("Kd8"));
+
+    EXPECT_NE(pgn::serialise(game).find("30... Kd8"), std::string::npos);
+}
+
+TEST(Pgn, WrapsMovetextAtEightyColumns)
+{
+    Game game;
+    playAll(game,
+        {"Nf3", "Nf6", "Ng1", "Ng8", "Nf3", "Nf6", "Ng1", "Ng8", "Nc3", "Nc6", "Nb1", "Nb8", "Nc3", "Nc6",
+            "Nb1", "Nb8"});
+
+    const std::string text = pgn::serialise(game);
+    std::size_t lineStart = 0;
+    while (lineStart < text.size()) {
+        const std::size_t lineEnd = text.find('\n', lineStart);
+        const std::size_t length = (lineEnd == std::string::npos ? text.size() : lineEnd) - lineStart;
+        EXPECT_LE(length, 80U) << text.substr(lineStart, length);
+        if (lineEnd == std::string::npos) {
+            break;
+        }
+        lineStart = lineEnd + 1;
+    }
+}
+
+} // namespace
+} // namespace chess

--- a/tests/movegen_test.cpp
+++ b/tests/movegen_test.cpp
@@ -1,0 +1,370 @@
+#include "chess/Fen.hpp"
+#include "chess/MoveGenerator.hpp"
+#include "chess/Rules.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace chess {
+namespace {
+
+Position mustParse(std::string_view text)
+{
+    fen::ParseResult result = fen::parse(text);
+    if (const auto* failure = std::get_if<fen::ParseError>(&result)) {
+        ADD_FAILURE() << "expected '" << text << "' to parse, got: " << failure->message;
+        return Position{};
+    }
+    return std::get<Position>(result);
+}
+
+// Every legal move from a square, in UCI form and sorted, so a test can state
+// the complete expected set rather than spot-checking one move at a time.
+std::vector<std::string> legalMovesFrom(const Position& position, Square from)
+{
+    std::vector<std::string> found;
+    for (const Move& move : generateLegalMoves(position)) {
+        if (move.from == from) {
+            found.push_back(move.toUci());
+        }
+    }
+    std::sort(found.begin(), found.end());
+    return found;
+}
+
+bool hasLegalMove(const Position& position, std::string_view uci)
+{
+    for (const Move& move : generateLegalMoves(position)) {
+        if (move.toUci() == uci) {
+            return true;
+        }
+    }
+    return false;
+}
+
+const Move* findLegalMove(const Position& position, std::string_view uci)
+{
+    static Move storage;
+    for (const Move& move : generateLegalMoves(position)) {
+        if (move.toUci() == uci) {
+            storage = move;
+            return &storage;
+        }
+    }
+    return nullptr;
+}
+
+TEST(MoveGenerator, StartingPositionOffersSixteenPawnAndFourKnightMoves)
+{
+    const MoveList moves = generateLegalMoves(Position::starting());
+    EXPECT_EQ(moves.size(), 20U);
+    EXPECT_TRUE(moves.contains(Square::E2, Square::E4));
+    EXPECT_TRUE(moves.contains(Square::G1, Square::F3));
+    EXPECT_FALSE(moves.contains(Square::E1, Square::E2));
+}
+
+TEST(MoveGenerator, PawnPushesTwoOnlyFromItsHomeRank)
+{
+    const Position start = Position::starting();
+    EXPECT_EQ(legalMovesFrom(start, Square::E2), (std::vector<std::string>{"e2e3", "e2e4"}));
+
+    const Position advanced = mustParse("rnbqkbnr/pppppppp/8/8/8/4P3/PPPP1PPP/RNBQKBNR w KQkq - 0 2");
+    EXPECT_EQ(legalMovesFrom(advanced, Square::E3), (std::vector<std::string>{"e3e4"}));
+}
+
+TEST(MoveGenerator, PawnDoesNotJumpOverAPiece)
+{
+    const Position blocked = mustParse("rnbqkbnr/pppppppp/8/8/8/4n3/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    EXPECT_TRUE(legalMovesFrom(blocked, Square::E2).empty());
+}
+
+TEST(MoveGenerator, PawnCapturesDiagonallyAndNotForwards)
+{
+    const Position position = mustParse("8/8/8/8/8/3p1p2/4P3/K6k w - - 0 1");
+    EXPECT_EQ(
+        legalMovesFrom(position, Square::E2), (std::vector<std::string>{"e2d3", "e2e3", "e2e4", "e2f3"}));
+
+    const Position headOn = mustParse("8/8/8/8/8/4p3/4P3/K6k w - - 0 1");
+    EXPECT_TRUE(legalMovesFrom(headOn, Square::E2).empty());
+}
+
+TEST(MoveGenerator, PromotionOffersAllFourPieces)
+{
+    const Position position = mustParse("8/4P3/8/8/8/8/8/K6k w - - 0 1");
+    EXPECT_EQ(
+        legalMovesFrom(position, Square::E7), (std::vector<std::string>{"e7e8b", "e7e8n", "e7e8q", "e7e8r"}));
+}
+
+TEST(MoveGenerator, PromotionByCaptureAlsoOffersAllFourPieces)
+{
+    const Position position = mustParse("3r4/4P3/8/8/8/8/8/K6k w - - 0 1");
+    EXPECT_EQ(legalMovesFrom(position, Square::E7),
+        (std::vector<std::string>{"e7d8b", "e7d8n", "e7d8q", "e7d8r", "e7e8b", "e7e8n", "e7e8q", "e7e8r"}));
+}
+
+TEST(MoveGenerator, PromotionReplacesThePawnWithTheChosenPiece)
+{
+    const Position position = mustParse("8/4P3/8/8/8/8/8/K6k w - - 0 1");
+    const Move* move = findLegalMove(position, "e7e8n");
+    ASSERT_NE(move, nullptr);
+
+    const Position after = applyMove(position, *move);
+    EXPECT_EQ(after.board.pieceAt(Square::E8), (Piece{PieceType::Knight, Color::White}));
+    EXPECT_TRUE(after.board.isEmpty(Square::E7));
+}
+
+TEST(MoveGenerator, EnPassantIsOfferedOnlyOnTheReplyToTheDoublePush)
+{
+    const Position afterDoublePush
+        = mustParse("rnbqkbnr/pp1ppppp/8/8/2pP4/8/PPP1PPPP/RNBQKBNR b KQkq d3 0 3");
+    EXPECT_TRUE(hasLegalMove(afterDoublePush, "c4d3"));
+
+    // Same placement, but no double push just happened.
+    const Position withoutTarget = mustParse("rnbqkbnr/pp1ppppp/8/8/2pP4/8/PPP1PPPP/RNBQKBNR b KQkq - 0 3");
+    EXPECT_FALSE(hasLegalMove(withoutTarget, "c4d3"));
+}
+
+TEST(MoveGenerator, EnPassantRemovesThePawnBesideTheDestination)
+{
+    const Position position = mustParse("rnbqkbnr/pp1ppppp/8/8/2pP4/8/PPP1PPPP/RNBQKBNR b KQkq d3 0 3");
+    const Move* move = findLegalMove(position, "c4d3");
+    ASSERT_NE(move, nullptr);
+    EXPECT_EQ(move->kind, MoveKind::EnPassant);
+
+    const Position after = applyMove(position, *move);
+    EXPECT_EQ(after.board.pieceAt(Square::D3), (Piece{PieceType::Pawn, Color::Black}));
+    EXPECT_TRUE(after.board.isEmpty(Square::D4)) << "the captured pawn stood on d4, not on d3";
+    EXPECT_TRUE(after.board.isEmpty(Square::C4));
+}
+
+// Both pawns leave the fifth rank at once, so a rook that was blocked twice
+// suddenly sees the king. Only a full legality check catches this; a
+// pin-detection shortcut that looks at the moving pawn alone does not.
+TEST(MoveGenerator, EnPassantIsIllegalWhenItDiscoversCheckAlongTheRank)
+{
+    const Position position = mustParse("8/8/8/K2pP2r/8/8/8/7k w - d6 0 2");
+    EXPECT_FALSE(hasLegalMove(position, "e5d6"));
+}
+
+TEST(MoveGenerator, DoublePushSetsTheEnPassantTarget)
+{
+    const Position start = Position::starting();
+    const Move* move = findLegalMove(start, "e2e4");
+    ASSERT_NE(move, nullptr);
+    EXPECT_EQ(move->kind, MoveKind::DoublePawnPush);
+    EXPECT_EQ(applyMove(start, *move).enPassantTarget, Square::E3);
+
+    const Move* single = findLegalMove(start, "e2e3");
+    ASSERT_NE(single, nullptr);
+    EXPECT_EQ(applyMove(start, *single).enPassantTarget, Square::None);
+}
+
+TEST(MoveGenerator, CastlesBothSidesWhenNothingStandsInTheWay)
+{
+    const Position position = mustParse("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1");
+    EXPECT_TRUE(hasLegalMove(position, "e1g1"));
+    EXPECT_TRUE(hasLegalMove(position, "e1c1"));
+}
+
+TEST(MoveGenerator, CastlingMovesTheRookToo)
+{
+    const Position position = mustParse("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1");
+
+    const Move* kingSide = findLegalMove(position, "e1g1");
+    ASSERT_NE(kingSide, nullptr);
+    const Position afterShort = applyMove(position, *kingSide);
+    EXPECT_EQ(afterShort.board.pieceAt(Square::G1), (Piece{PieceType::King, Color::White}));
+    EXPECT_EQ(afterShort.board.pieceAt(Square::F1), (Piece{PieceType::Rook, Color::White}));
+    EXPECT_TRUE(afterShort.board.isEmpty(Square::H1));
+
+    const Move* queenSide = findLegalMove(position, "e1c1");
+    ASSERT_NE(queenSide, nullptr);
+    const Position afterLong = applyMove(position, *queenSide);
+    EXPECT_EQ(afterLong.board.pieceAt(Square::C1), (Piece{PieceType::King, Color::White}));
+    EXPECT_EQ(afterLong.board.pieceAt(Square::D1), (Piece{PieceType::Rook, Color::White}));
+    EXPECT_TRUE(afterLong.board.isEmpty(Square::A1));
+}
+
+TEST(MoveGenerator, CannotCastleWithoutTheRight)
+{
+    const Position position = mustParse("r3k2r/8/8/8/8/8/8/R3K2R w - - 0 1");
+    EXPECT_FALSE(hasLegalMove(position, "e1g1"));
+    EXPECT_FALSE(hasLegalMove(position, "e1c1"));
+}
+
+TEST(MoveGenerator, CannotCastleThroughAnOccupiedSquare)
+{
+    EXPECT_FALSE(hasLegalMove(mustParse("r3k2r/8/8/8/8/8/8/R3KB1R w KQkq - 0 1"), "e1g1"));
+    EXPECT_FALSE(hasLegalMove(mustParse("r3k2r/8/8/8/8/8/8/RN2K2R w KQkq - 0 1"), "e1c1"));
+}
+
+TEST(MoveGenerator, CannotCastleOutOfCheck)
+{
+    const Position position = mustParse("r3k2r/8/8/8/8/8/4r3/R3K2R w KQ - 0 1");
+    EXPECT_FALSE(hasLegalMove(position, "e1g1"));
+    EXPECT_FALSE(hasLegalMove(position, "e1c1"));
+}
+
+TEST(MoveGenerator, CannotCastleThroughAnAttackedSquare)
+{
+    const Position kingSide = mustParse("r3k2r/8/8/8/8/8/5r2/R3K2R w KQ - 0 1");
+    EXPECT_FALSE(hasLegalMove(kingSide, "e1g1"));
+    EXPECT_TRUE(hasLegalMove(kingSide, "e1c1")) << "the other side is untouched";
+
+    const Position queenSide = mustParse("r3k2r/8/8/8/8/8/3r4/R3K2R w KQ - 0 1");
+    EXPECT_FALSE(hasLegalMove(queenSide, "e1c1"));
+    EXPECT_TRUE(hasLegalMove(queenSide, "e1g1"));
+}
+
+TEST(MoveGenerator, CannotCastleIntoCheck)
+{
+    const Position position = mustParse("r3k2r/8/8/8/8/8/6r1/R3K2R w KQ - 0 1");
+    EXPECT_FALSE(hasLegalMove(position, "e1g1"));
+}
+
+// Only the b-file square must be empty for the rook to pass; the king never
+// stands on it, so an attack there does not prevent the castle.
+TEST(MoveGenerator, QueenSideCastleIsAllowedWhenOnlyTheBFileIsAttacked)
+{
+    const Position position = mustParse("r3k2r/8/8/8/8/8/1r6/R3K2R w KQ - 0 1");
+    EXPECT_TRUE(hasLegalMove(position, "e1c1"));
+}
+
+TEST(MoveGenerator, MovingTheKingGivesUpBothCastlingRights)
+{
+    const Position position = mustParse("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1");
+    const Move* move = findLegalMove(position, "e1e2");
+    ASSERT_NE(move, nullptr);
+
+    const Position after = applyMove(position, *move);
+    EXPECT_FALSE(after.castling.has(CastlingRights::WhiteKingSide));
+    EXPECT_FALSE(after.castling.has(CastlingRights::WhiteQueenSide));
+    EXPECT_TRUE(after.castling.has(CastlingRights::BlackKingSide));
+}
+
+TEST(MoveGenerator, MovingARookGivesUpOnlyThatSidesRight)
+{
+    const Position position = mustParse("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1");
+    const Move* move = findLegalMove(position, "h1h2");
+    ASSERT_NE(move, nullptr);
+
+    const Position after = applyMove(position, *move);
+    EXPECT_FALSE(after.castling.has(CastlingRights::WhiteKingSide));
+    EXPECT_TRUE(after.castling.has(CastlingRights::WhiteQueenSide));
+}
+
+// The easy one to miss: Black never moved a piece, but its rook is gone.
+TEST(MoveGenerator, CapturingARookGivesUpTheOwnersRight)
+{
+    const Position position = mustParse("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1");
+    const Move* move = findLegalMove(position, "a1a8");
+    ASSERT_NE(move, nullptr);
+
+    const Position after = applyMove(position, *move);
+    EXPECT_FALSE(after.castling.has(CastlingRights::BlackQueenSide));
+    EXPECT_TRUE(after.castling.has(CastlingRights::BlackKingSide));
+}
+
+TEST(MoveGenerator, APinnedPieceMayNotAbandonTheKing)
+{
+    // The white knight on e2 shields the king from the rook on e8.
+    const Position position = mustParse("4r3/8/8/8/8/8/4N3/4K3 w - - 0 1");
+    EXPECT_TRUE(legalMovesFrom(position, Square::E2).empty());
+}
+
+TEST(MoveGenerator, APinnedPieceMayStillMoveAlongThePin)
+{
+    const Position position = mustParse("4r3/8/8/8/8/8/4R3/4K3 w - - 0 1");
+    const std::vector<std::string> moves = legalMovesFrom(position, Square::E2);
+    EXPECT_EQ(moves, (std::vector<std::string>{"e2e3", "e2e4", "e2e5", "e2e6", "e2e7", "e2e8"}));
+}
+
+TEST(MoveGenerator, WhenInCheckOnlyMovesThatAnswerItAreLegal)
+{
+    // Black's rook on e8 checks the white king; White may block on e4, capture
+    // nothing, or step aside.
+    const Position position = mustParse("4r3/8/8/8/8/8/8/4K3 w - - 0 1");
+    const MoveList moves = generateLegalMoves(position);
+    for (const Move& move : moves) {
+        EXPECT_NE(fileOf(move.to), File::E) << "king stayed on the checked file: " << move.toUci();
+    }
+    EXPECT_FALSE(moves.empty());
+}
+
+TEST(MoveGenerator, KingsMayNotStandBesideEachOther)
+{
+    // Kings two ranks apart: d2 would put them side by side, so it is out.
+    const Position position = mustParse("8/8/8/8/8/3k4/8/3K4 w - - 0 1");
+    EXPECT_FALSE(hasLegalMove(position, "d1d2"));
+    EXPECT_FALSE(hasLegalMove(position, "d1c2"));
+    EXPECT_FALSE(hasLegalMove(position, "d1e2"));
+    EXPECT_TRUE(hasLegalMove(position, "d1c1"));
+    EXPECT_TRUE(hasLegalMove(position, "d1e1"));
+}
+
+TEST(MoveGenerator, PseudoLegalIncludesMovesThatLeaveTheKingInCheck)
+{
+    const Position position = mustParse("4r3/8/8/8/8/8/4N3/4K3 w - - 0 1");
+
+    bool pseudoLegalHasKnightMove = false;
+    for (const Move& move : generatePseudoLegalMoves(position)) {
+        if (move.from == Square::E2) {
+            pseudoLegalHasKnightMove = true;
+        }
+    }
+    EXPECT_TRUE(pseudoLegalHasKnightMove);
+    EXPECT_TRUE(legalMovesFrom(position, Square::E2).empty());
+}
+
+TEST(MoveList, FindMatchesOnFromToAndPromotion)
+{
+    const Position position = mustParse("8/4P3/8/8/8/8/8/K6k w - - 0 1");
+    const MoveList moves = generateLegalMoves(position);
+
+    ASSERT_NE(moves.find(Square::E7, Square::E8, PieceType::Queen), nullptr);
+    ASSERT_NE(moves.find(Square::E7, Square::E8, PieceType::Knight), nullptr);
+    EXPECT_EQ(moves.find(Square::E7, Square::E8, PieceType::Queen)->promotion, PieceType::Queen);
+    EXPECT_EQ(moves.find(Square::E7, Square::E8), nullptr) << "a promotion needs its piece named";
+    EXPECT_EQ(moves.find(Square::A1, Square::A2, PieceType::Queen), nullptr);
+}
+
+TEST(ApplyMove, FiftyMoveCounterResetsOnPawnMovesAndCaptures)
+{
+    const Position quiet = mustParse("8/8/8/8/8/5n2/8/K6k b - - 10 20");
+    const Move* knightMove = findLegalMove(quiet, "f3g1");
+    ASSERT_NE(knightMove, nullptr);
+    EXPECT_EQ(applyMove(quiet, *knightMove).halfmoveClock, 11);
+
+    const Position pawn = mustParse("8/8/8/8/8/8/4P3/K6k w - - 10 20");
+    const Move* pawnMove = findLegalMove(pawn, "e2e3");
+    ASSERT_NE(pawnMove, nullptr);
+    EXPECT_EQ(applyMove(pawn, *pawnMove).halfmoveClock, 0);
+
+    const Position capture = mustParse("7k/8/8/8/8/6n1/8/K5R1 w - - 10 20");
+    const Move* captureMove = findLegalMove(capture, "g1g3");
+    ASSERT_NE(captureMove, nullptr);
+    EXPECT_EQ(applyMove(capture, *captureMove).halfmoveClock, 0);
+}
+
+TEST(ApplyMove, FullmoveNumberAdvancesAfterBlackMoves)
+{
+    const Position white = Position::starting();
+    const Move* whiteMove = findLegalMove(white, "e2e4");
+    ASSERT_NE(whiteMove, nullptr);
+    const Position afterWhite = applyMove(white, *whiteMove);
+    EXPECT_EQ(afterWhite.fullmoveNumber, 1);
+    EXPECT_EQ(afterWhite.sideToMove, Color::Black);
+
+    const Move* blackMove = findLegalMove(afterWhite, "e7e5");
+    ASSERT_NE(blackMove, nullptr);
+    const Position afterBlack = applyMove(afterWhite, *blackMove);
+    EXPECT_EQ(afterBlack.fullmoveNumber, 2);
+    EXPECT_EQ(afterBlack.sideToMove, Color::White);
+}
+
+} // namespace
+} // namespace chess

--- a/tests/movegen_test.cpp
+++ b/tests/movegen_test.cpp
@@ -325,11 +325,24 @@ TEST(MoveList, FindMatchesOnFromToAndPromotion)
     const Position position = mustParse("8/4P3/8/8/8/8/8/K6k w - - 0 1");
     const MoveList moves = generateLegalMoves(position);
 
-    ASSERT_NE(moves.find(Square::E7, Square::E8, PieceType::Queen), nullptr);
-    ASSERT_NE(moves.find(Square::E7, Square::E8, PieceType::Knight), nullptr);
+    ASSERT_TRUE(moves.find(Square::E7, Square::E8, PieceType::Queen).has_value());
+    ASSERT_TRUE(moves.find(Square::E7, Square::E8, PieceType::Knight).has_value());
     EXPECT_EQ(moves.find(Square::E7, Square::E8, PieceType::Queen)->promotion, PieceType::Queen);
-    EXPECT_EQ(moves.find(Square::E7, Square::E8), nullptr) << "a promotion needs its piece named";
-    EXPECT_EQ(moves.find(Square::A1, Square::A2, PieceType::Queen), nullptr);
+    EXPECT_FALSE(moves.find(Square::E7, Square::E8).has_value()) << "a promotion needs its piece named";
+    EXPECT_FALSE(moves.find(Square::A1, Square::A2, PieceType::Queen).has_value());
+}
+
+// find returns by value on purpose. Writing the call against a temporary list
+// is the natural thing to do, and a returned pointer would dangle at the
+// semicolon. Address sanitizer caught exactly this in Game::play.
+TEST(MoveList, FindSurvivesBeingCalledOnATemporaryList)
+{
+    const Position position = mustParse("8/4P3/8/8/8/8/8/K6k w - - 0 1");
+    const auto found = generateLegalMoves(position).find(Square::E7, Square::E8, PieceType::Queen);
+
+    ASSERT_TRUE(found.has_value());
+    EXPECT_EQ(found->from, Square::E7);
+    EXPECT_EQ(found->promotion, PieceType::Queen);
 }
 
 TEST(ApplyMove, FiftyMoveCounterResetsOnPawnMovesAndCaptures)

--- a/tests/perft_test.cpp
+++ b/tests/perft_test.cpp
@@ -1,0 +1,94 @@
+#include "chess/Fen.hpp"
+#include "chess/MoveGenerator.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace chess {
+namespace {
+
+Position mustParse(std::string_view text)
+{
+    fen::ParseResult result = fen::parse(text);
+    if (const auto* failure = std::get_if<fen::ParseError>(&result)) {
+        ADD_FAILURE() << "expected '" << text << "' to parse, got: " << failure->message;
+        return Position{};
+    }
+    return std::get<Position>(result);
+}
+
+// The six positions the Chess Programming Wiki publishes perft node counts for.
+// They are chosen between them to exercise every rule that is easy to get
+// wrong: Kiwipete is dense with castling and pinned pieces, position 3 is an
+// en-passant and promotion race, position 4 has promotions with check, and
+// positions 5 and 6 are known to catch castling-rights bugs.
+//
+// Because the expected counts are exact, a single mishandled case shows up as
+// a wrong number here rather than as a subtle misbehaviour during a game.
+struct PerftCase {
+    std::string_view name;
+    std::string_view fenText;
+    int depth;
+    std::uint64_t expected;
+};
+
+constexpr std::string_view kStart = fen::kStartingPosition;
+constexpr std::string_view kKiwipete = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1";
+constexpr std::string_view kPosition3 = "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1";
+constexpr std::string_view kPosition4 = "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1";
+constexpr std::string_view kPosition5 = "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8";
+constexpr std::string_view kPosition6
+    = "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10";
+
+class Perft : public testing::TestWithParam<PerftCase> { };
+
+TEST_P(Perft, MatchesThePublishedNodeCount)
+{
+    const PerftCase& testCase = GetParam();
+    EXPECT_EQ(perft(mustParse(testCase.fenText), testCase.depth), testCase.expected)
+        << testCase.name << " at depth " << testCase.depth;
+}
+
+// Every position is taken to depth 4, and the start position and position 3 to
+// depth 5. That is deep enough for castling, en passant and promotion to
+// interact, which is where generators usually break. It costs about a second
+// in an optimised build and about fifteen in a debug one.
+INSTANTIATE_TEST_SUITE_P(Standard, Perft,
+    testing::Values(PerftCase{"start", kStart, 1, 20}, PerftCase{"start", kStart, 2, 400},
+        PerftCase{"start", kStart, 3, 8902}, PerftCase{"start", kStart, 4, 197281},
+        PerftCase{"start", kStart, 5, 4865609}, PerftCase{"kiwipete", kKiwipete, 1, 48},
+        PerftCase{"kiwipete", kKiwipete, 2, 2039}, PerftCase{"kiwipete", kKiwipete, 3, 97862},
+        PerftCase{"kiwipete", kKiwipete, 4, 4085603}, PerftCase{"position3", kPosition3, 1, 14},
+        PerftCase{"position3", kPosition3, 2, 191}, PerftCase{"position3", kPosition3, 3, 2812},
+        PerftCase{"position3", kPosition3, 4, 43238}, PerftCase{"position3", kPosition3, 5, 674624},
+        PerftCase{"position4", kPosition4, 1, 6}, PerftCase{"position4", kPosition4, 2, 264},
+        PerftCase{"position4", kPosition4, 3, 9467}, PerftCase{"position4", kPosition4, 4, 422333},
+        PerftCase{"position5", kPosition5, 1, 44}, PerftCase{"position5", kPosition5, 2, 1486},
+        PerftCase{"position5", kPosition5, 3, 62379}, PerftCase{"position5", kPosition5, 4, 2103487},
+        PerftCase{"position6", kPosition6, 1, 46}, PerftCase{"position6", kPosition6, 2, 2079},
+        PerftCase{"position6", kPosition6, 3, 89890}, PerftCase{"position6", kPosition6, 4, 3894594}),
+    [](const testing::TestParamInfo<PerftCase>& info) {
+        return std::string(info.param.name) + "_depth" + std::to_string(info.param.depth);
+    });
+
+#ifdef CINES_SLOW_TESTS
+// Hundreds of millions of nodes. Configure with -DCINES_SLOW_TESTS=ON to
+// include them; CI does not. They have been run and pass.
+INSTANTIATE_TEST_SUITE_P(Deep, Perft,
+    testing::Values(PerftCase{"start", kStart, 6, 119060324}, PerftCase{"kiwipete", kKiwipete, 5, 193690690},
+        PerftCase{"position3", kPosition3, 6, 11030083}, PerftCase{"position4", kPosition4, 5, 15833292}),
+    [](const testing::TestParamInfo<PerftCase>& info) {
+        return std::string(info.param.name) + "_depth" + std::to_string(info.param.depth);
+    });
+#endif
+
+TEST(Perft, DepthZeroCountsThePositionItself)
+{
+    EXPECT_EQ(perft(Position::starting(), 0), 1U);
+}
+
+} // namespace
+} // namespace chess

--- a/tests/perft_test.cpp
+++ b/tests/perft_test.cpp
@@ -45,6 +45,15 @@ constexpr std::string_view kPosition6
 
 class Perft : public testing::TestWithParam<PerftCase> { };
 
+// Named rather than written inline at each instantiation. INSTANTIATE_TEST_SUITE_P
+// expands its name-generator argument inside a function that already has a
+// parameter called "info", so an inline lambda taking "info" shadows it --
+// which gcc rejects under -Wshadow even though clang and MSVC accept it.
+std::string perftCaseName(const testing::TestParamInfo<PerftCase>& parameter)
+{
+    return std::string(parameter.param.name) + "_depth" + std::to_string(parameter.param.depth);
+}
+
 TEST_P(Perft, MatchesThePublishedNodeCount)
 {
     const PerftCase& testCase = GetParam();
@@ -70,9 +79,7 @@ INSTANTIATE_TEST_SUITE_P(Standard, Perft,
         PerftCase{"position5", kPosition5, 3, 62379}, PerftCase{"position5", kPosition5, 4, 2103487},
         PerftCase{"position6", kPosition6, 1, 46}, PerftCase{"position6", kPosition6, 2, 2079},
         PerftCase{"position6", kPosition6, 3, 89890}, PerftCase{"position6", kPosition6, 4, 3894594}),
-    [](const testing::TestParamInfo<PerftCase>& info) {
-        return std::string(info.param.name) + "_depth" + std::to_string(info.param.depth);
-    });
+    perftCaseName);
 
 #ifdef CINES_SLOW_TESTS
 // Hundreds of millions of nodes. Configure with -DCINES_SLOW_TESTS=ON to
@@ -80,9 +87,7 @@ INSTANTIATE_TEST_SUITE_P(Standard, Perft,
 INSTANTIATE_TEST_SUITE_P(Deep, Perft,
     testing::Values(PerftCase{"start", kStart, 6, 119060324}, PerftCase{"kiwipete", kKiwipete, 5, 193690690},
         PerftCase{"position3", kPosition3, 6, 11030083}, PerftCase{"position4", kPosition4, 5, 15833292}),
-    [](const testing::TestParamInfo<PerftCase>& info) {
-        return std::string(info.param.name) + "_depth" + std::to_string(info.param.depth);
-    });
+    perftCaseName);
 #endif
 
 TEST(Perft, DepthZeroCountsThePositionItself)

--- a/tests/rules_test.cpp
+++ b/tests/rules_test.cpp
@@ -1,0 +1,204 @@
+#include "chess/Fen.hpp"
+#include "chess/MoveGenerator.hpp"
+#include "chess/Rules.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string_view>
+
+namespace chess {
+namespace {
+
+Position mustParse(std::string_view text)
+{
+    fen::ParseResult result = fen::parse(text);
+    if (const auto* failure = std::get_if<fen::ParseError>(&result)) {
+        ADD_FAILURE() << "expected '" << text << "' to parse, got: " << failure->message;
+        return Position{};
+    }
+    return std::get<Position>(result);
+}
+
+TEST(IsSquareAttacked, PawnsAttackForwardDiagonallyOnly)
+{
+    const Board board = mustParse("8/8/8/8/8/8/4P3/8 w - - 0 1").board;
+    EXPECT_TRUE(isSquareAttacked(board, Square::D3, Color::White));
+    EXPECT_TRUE(isSquareAttacked(board, Square::F3, Color::White));
+    EXPECT_FALSE(isSquareAttacked(board, Square::E3, Color::White)) << "a pawn does not attack ahead";
+    EXPECT_FALSE(isSquareAttacked(board, Square::D1, Color::White)) << "nor behind";
+}
+
+TEST(IsSquareAttacked, BlackPawnsAttackTheOtherWay)
+{
+    const Board board = mustParse("8/4p3/8/8/8/8/8/8 w - - 0 1").board;
+    EXPECT_TRUE(isSquareAttacked(board, Square::D6, Color::Black));
+    EXPECT_TRUE(isSquareAttacked(board, Square::F6, Color::Black));
+    EXPECT_FALSE(isSquareAttacked(board, Square::D8, Color::Black));
+}
+
+TEST(IsSquareAttacked, KnightsReachAllEightHops)
+{
+    const Board board = mustParse("8/8/8/3N4/8/8/8/8 w - - 0 1").board;
+    for (const Square square :
+        {Square::C7, Square::E7, Square::B6, Square::F6, Square::B4, Square::F4, Square::C3, Square::E3}) {
+        EXPECT_TRUE(isSquareAttacked(board, square, Color::White)) << toString(square);
+    }
+    EXPECT_FALSE(isSquareAttacked(board, Square::D6, Color::White));
+}
+
+TEST(IsSquareAttacked, SlidersAreBlockedByTheFirstPieceOnTheRay)
+{
+    const Board open = mustParse("8/8/8/8/8/8/8/R6k w - - 0 1").board;
+    EXPECT_TRUE(isSquareAttacked(open, Square::H1, Color::White));
+
+    const Board blocked = mustParse("8/8/8/8/8/8/8/R3n2k w - - 0 1").board;
+    EXPECT_TRUE(isSquareAttacked(blocked, Square::E1, Color::White)) << "the blocker itself is attacked";
+    EXPECT_FALSE(isSquareAttacked(blocked, Square::H1, Color::White)) << "but nothing beyond it";
+}
+
+TEST(IsSquareAttacked, QueensCoverBothRookAndBishopLines)
+{
+    const Board board = mustParse("8/8/8/3Q4/8/8/8/8 w - - 0 1").board;
+    EXPECT_TRUE(isSquareAttacked(board, Square::D1, Color::White));
+    EXPECT_TRUE(isSquareAttacked(board, Square::A5, Color::White));
+    EXPECT_TRUE(isSquareAttacked(board, Square::H1, Color::White));
+    EXPECT_TRUE(isSquareAttacked(board, Square::A8, Color::White));
+    EXPECT_FALSE(isSquareAttacked(board, Square::E3, Color::White));
+}
+
+TEST(IsSquareAttacked, IgnoresPiecesOfTheOtherColour)
+{
+    const Board board = mustParse("8/8/8/3r4/8/8/8/8 w - - 0 1").board;
+    EXPECT_TRUE(isSquareAttacked(board, Square::D1, Color::Black));
+    EXPECT_FALSE(isSquareAttacked(board, Square::D1, Color::White));
+}
+
+TEST(IsInCheck, ReportsTheSideWhoseKingIsAttacked)
+{
+    const Position position = mustParse("4r3/8/8/8/8/8/8/4K3 w - - 0 1");
+    EXPECT_TRUE(isInCheck(position));
+    EXPECT_TRUE(isInCheck(position, Color::White));
+    EXPECT_FALSE(isInCheck(position, Color::Black));
+}
+
+TEST(IsInCheck, APositionWithoutAKingIsNotInCheck)
+{
+    const Position position = mustParse("4r3/8/8/8/8/8/8/8 w - - 0 1");
+    EXPECT_FALSE(isInCheck(position, Color::White));
+}
+
+// The 2012 validation::check() returned 0 unconditionally, so no game ever
+// ended. These are the cases it never detected.
+TEST(Terminal, FoolsMateIsCheckmate)
+{
+    const Position position = mustParse("rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 1 3");
+    EXPECT_TRUE(isInCheck(position));
+    EXPECT_TRUE(generateLegalMoves(position).empty());
+    EXPECT_EQ(terminalReason(position), TerminalReason::Checkmate);
+    EXPECT_EQ(outcomeFor(terminalReason(position), position.sideToMove), Outcome::BlackWins);
+}
+
+TEST(Terminal, BackRankMateIsCheckmate)
+{
+    const Position position = mustParse("6k1/5ppp/8/8/8/8/8/R5K1 b - - 0 1");
+    EXPECT_EQ(terminalReason(position), TerminalReason::None) << "not yet -- the rook must reach the rank";
+
+    const Position mated = mustParse("R5k1/5ppp/8/8/8/8/8/6K1 b - - 0 1");
+    EXPECT_EQ(terminalReason(mated), TerminalReason::Checkmate);
+}
+
+TEST(Terminal, StalemateIsNotCheckmate)
+{
+    // Black to move, not in check, and with no legal move at all.
+    const Position position = mustParse("7k/5Q2/6K1/8/8/8/8/8 b - - 0 1");
+    EXPECT_FALSE(isInCheck(position));
+    EXPECT_TRUE(generateLegalMoves(position).empty());
+    EXPECT_EQ(terminalReason(position), TerminalReason::Stalemate);
+    EXPECT_EQ(outcomeFor(terminalReason(position), position.sideToMove), Outcome::Draw);
+}
+
+TEST(Terminal, CheckAloneDoesNotEndTheGame)
+{
+    const Position position = mustParse("4r3/8/8/8/8/8/8/4K3 w - - 0 1");
+    EXPECT_TRUE(isInCheck(position));
+    EXPECT_EQ(terminalReason(position), TerminalReason::None);
+    EXPECT_EQ(outcomeFor(TerminalReason::None, Color::White), Outcome::Ongoing);
+}
+
+TEST(Terminal, FiftyMoveRuleAppliesAtOneHundredPlies)
+{
+    EXPECT_EQ(terminalReason(mustParse("4k3/8/8/4r3/8/8/8/4K3 w - - 99 60")), TerminalReason::None);
+    EXPECT_EQ(terminalReason(mustParse("4k3/8/8/4r3/8/8/8/4K3 w - - 100 60")), TerminalReason::FiftyMoveRule);
+}
+
+// A mate delivered on the hundredth ply is a mate, not a fifty-move draw.
+TEST(Terminal, CheckmateOutranksTheFiftyMoveRule)
+{
+    const Position position = mustParse("R5k1/5ppp/8/8/8/8/8/6K1 b - - 100 60");
+    EXPECT_EQ(terminalReason(position), TerminalReason::Checkmate);
+}
+
+TEST(InsufficientMaterial, KingAgainstKing)
+{
+    EXPECT_TRUE(hasInsufficientMaterial(mustParse("4k3/8/8/8/8/8/8/4K3 w - - 0 1")));
+}
+
+TEST(InsufficientMaterial, KingAndOneMinorPieceAgainstKing)
+{
+    EXPECT_TRUE(hasInsufficientMaterial(mustParse("4k3/8/8/8/8/8/8/3BK3 w - - 0 1")));
+    EXPECT_TRUE(hasInsufficientMaterial(mustParse("4k3/8/8/8/8/8/8/3NK3 w - - 0 1")));
+    EXPECT_TRUE(hasInsufficientMaterial(mustParse("3bk3/8/8/8/8/8/8/4K3 w - - 0 1")));
+}
+
+TEST(InsufficientMaterial, BishopsOnTheSameColourOfSquareCanNeverMeet)
+{
+    // c1 and f8 are both dark squares.
+    EXPECT_TRUE(hasInsufficientMaterial(mustParse("4kb2/8/8/8/8/8/8/2B1K3 w - - 0 1")));
+
+    // c1 is dark, c8 is light.
+    EXPECT_FALSE(hasInsufficientMaterial(mustParse("2b1k3/8/8/8/8/8/8/2B1K3 w - - 0 1")));
+}
+
+TEST(InsufficientMaterial, AnyPawnRookOrQueenIsEnough)
+{
+    EXPECT_FALSE(hasInsufficientMaterial(mustParse("4k3/8/8/8/8/8/4P3/4K3 w - - 0 1")));
+    EXPECT_FALSE(hasInsufficientMaterial(mustParse("4k3/8/8/8/8/8/8/R3K3 w - - 0 1")));
+    EXPECT_FALSE(hasInsufficientMaterial(mustParse("4k3/8/8/8/8/8/8/3QK3 w - - 0 1")));
+}
+
+// Two knights cannot force mate, but mate is reachable if the defender helps,
+// so the position is not dead and play continues.
+TEST(InsufficientMaterial, TwoKnightsAgainstAKingIsStillPlayable)
+{
+    EXPECT_FALSE(hasInsufficientMaterial(mustParse("4k3/8/8/8/8/8/8/1N1NK3 w - - 0 1")));
+}
+
+TEST(InsufficientMaterial, TwoBishopsAgainstAKingIsStillPlayable)
+{
+    EXPECT_FALSE(hasInsufficientMaterial(mustParse("4k3/8/8/8/8/8/8/2BBK3 w - - 0 1")));
+}
+
+TEST(Terminal, InsufficientMaterialIsReportedAsADraw)
+{
+    const Position position = mustParse("4k3/8/8/8/8/8/8/3BK3 w - - 0 1");
+    EXPECT_EQ(terminalReason(position), TerminalReason::InsufficientMaterial);
+    EXPECT_EQ(outcomeFor(terminalReason(position), position.sideToMove), Outcome::Draw);
+}
+
+TEST(Outcome, CheckmateLosesForWhoeverIsToMove)
+{
+    EXPECT_EQ(outcomeFor(TerminalReason::Checkmate, Color::White), Outcome::BlackWins);
+    EXPECT_EQ(outcomeFor(TerminalReason::Checkmate, Color::Black), Outcome::WhiteWins);
+}
+
+TEST(Outcome, EveryOtherTerminalReasonIsADraw)
+{
+    for (const TerminalReason reason : {TerminalReason::Stalemate, TerminalReason::FiftyMoveRule,
+             TerminalReason::ThreefoldRepetition, TerminalReason::InsufficientMaterial}) {
+        EXPECT_EQ(outcomeFor(reason, Color::White), Outcome::Draw);
+        EXPECT_EQ(outcomeFor(reason, Color::Black), Outcome::Draw);
+    }
+}
+
+} // namespace
+} // namespace chess

--- a/tests/san_test.cpp
+++ b/tests/san_test.cpp
@@ -1,0 +1,195 @@
+#include "chess/Fen.hpp"
+#include "chess/MoveGenerator.hpp"
+#include "chess/San.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+
+namespace chess {
+namespace {
+
+Position mustParse(std::string_view text)
+{
+    fen::ParseResult result = fen::parse(text);
+    if (const auto* failure = std::get_if<fen::ParseError>(&result)) {
+        ADD_FAILURE() << "expected '" << text << "' to parse, got: " << failure->message;
+        return Position{};
+    }
+    return std::get<Position>(result);
+}
+
+// The SAN spelling of the legal move written in UCI form, so a test can name
+// the move unambiguously and assert how it should be written.
+std::string sanFor(const Position& position, std::string_view uci)
+{
+    for (const Move& move : generateLegalMoves(position)) {
+        if (move.toUci() == uci) {
+            return san::toSan(position, move);
+        }
+    }
+    ADD_FAILURE() << uci << " is not legal in " << fen::serialise(position);
+    return {};
+}
+
+TEST(San, PlainPawnAndPieceMoves)
+{
+    const Position start = Position::starting();
+    EXPECT_EQ(sanFor(start, "e2e4"), "e4");
+    EXPECT_EQ(sanFor(start, "g1f3"), "Nf3");
+}
+
+TEST(San, CapturesUseAnX)
+{
+    const Position position = mustParse("rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2");
+    EXPECT_EQ(sanFor(position, "e4d5"), "exd5");
+
+    const Position pieceCapture = mustParse("rnbqkbnr/ppp1pppp/8/3p4/8/5N2/PPPPPPPP/RNBQKB1R w KQkq - 0 2");
+    EXPECT_EQ(sanFor(pieceCapture, "f3e5"), "Ne5");
+}
+
+// A pawn capture names its file whether or not anything is ambiguous, which is
+// the one place SAN is not minimal.
+TEST(San, PawnCapturesAlwaysNameTheirFile)
+{
+    const Position position = mustParse("8/8/8/3p4/4P3/8/8/K6k w - - 0 1");
+    EXPECT_EQ(sanFor(position, "e4d5"), "exd5");
+}
+
+TEST(San, CastlingUsesLetterO)
+{
+    const Position position = mustParse("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1");
+    EXPECT_EQ(sanFor(position, "e1g1"), "O-O");
+    EXPECT_EQ(sanFor(position, "e1c1"), "O-O-O");
+}
+
+TEST(San, PromotionNamesThePieceAfterAnEquals)
+{
+    const Position position = mustParse("8/4P3/8/8/8/8/8/K6k w - - 0 1");
+    EXPECT_EQ(sanFor(position, "e7e8q"), "e8=Q");
+    EXPECT_EQ(sanFor(position, "e7e8n"), "e8=N");
+
+    const Position capturing = mustParse("3r4/4P3/8/8/8/8/8/K6k w - - 0 1");
+    EXPECT_EQ(sanFor(capturing, "e7d8q"), "exd8=Q");
+}
+
+// Two knights reach d2 from b1 and f3; they differ in file, so the file alone
+// separates them.
+TEST(San, DisambiguatesByFileWhenFilesDiffer)
+{
+    const Position position = mustParse("4k3/8/8/8/8/5N2/8/1N2K3 w - - 0 1");
+    EXPECT_EQ(sanFor(position, "b1d2"), "Nbd2");
+    EXPECT_EQ(sanFor(position, "f3d2"), "Nfd2");
+}
+
+// Two rooks on the same file must be told apart by rank.
+TEST(San, DisambiguatesByRankWhenFilesMatch)
+{
+    const Position position = mustParse("4k3/8/8/8/R7/8/8/R3K3 w - - 0 1");
+    EXPECT_EQ(sanFor(position, "a1a3"), "R1a3");
+    EXPECT_EQ(sanFor(position, "a4a3"), "R4a3");
+}
+
+// Three queens reaching one square, which needs promoted pieces to arise. All
+// three forms appear at once here: b2 has a rival on its file and another on
+// its rank, so it needs both coordinates; the other two need only one each.
+TEST(San, DisambiguatesByFileAndRankWhenNeitherAloneIsEnough)
+{
+    const Position position = mustParse("k7/8/1Q6/8/8/8/1Q3Q2/7K w - - 0 1");
+    EXPECT_EQ(sanFor(position, "b2f6"), "Qb2f6");
+    EXPECT_EQ(sanFor(position, "b6f6"), "Q6f6");
+    EXPECT_EQ(sanFor(position, "f2f6"), "Qff6");
+}
+
+TEST(San, DoesNotDisambiguateWhenTheRivalMoveIsIllegal)
+{
+    // The knight on f3 is pinned by the rook on e8, so only b1 can reach d2
+    // and no disambiguation is needed.
+    const Position position = mustParse("4r3/8/8/8/8/4N3/8/1N2K3 w - - 0 1");
+    EXPECT_EQ(sanFor(position, "b1d2"), "Nd2");
+}
+
+TEST(San, AppendsAPlusForCheck)
+{
+    const Position position = mustParse("4k3/8/8/8/8/8/8/R3K3 w - - 0 1");
+    EXPECT_EQ(sanFor(position, "a1a8"), "Ra8+");
+}
+
+TEST(San, AppendsAHashForCheckmate)
+{
+    const Position position = mustParse("6k1/5ppp/8/8/8/8/8/R5K1 w - - 0 1");
+    EXPECT_EQ(sanFor(position, "a1a8"), "Ra8#");
+}
+
+TEST(San, ScholarsMateReadsAsExpected)
+{
+    const Position position = mustParse("r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 4 4");
+    EXPECT_EQ(sanFor(position, "f3f7"), "Qxf7#");
+}
+
+TEST(SanParse, ReadsWhatToSanWrites)
+{
+    const Position position
+        = mustParse("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+    for (const Move& move : generateLegalMoves(position)) {
+        const std::string text = san::toSan(position, move);
+        const auto parsed = san::parse(position, text);
+        ASSERT_TRUE(parsed.has_value()) << text;
+        EXPECT_EQ(*parsed, move) << text;
+    }
+}
+
+TEST(SanParse, CheckAndMateSuffixesAreOptional)
+{
+    const Position position = mustParse("4k3/8/8/8/8/8/8/R3K3 w - - 0 1");
+    EXPECT_TRUE(san::parse(position, "Ra8").has_value());
+    EXPECT_TRUE(san::parse(position, "Ra8+").has_value());
+    EXPECT_EQ(san::parse(position, "Ra8"), san::parse(position, "Ra8+"));
+}
+
+TEST(SanParse, AnnotationGlyphsAreIgnored)
+{
+    const Position start = Position::starting();
+    EXPECT_EQ(san::parse(start, "e4!?"), san::parse(start, "e4"));
+    EXPECT_EQ(san::parse(start, "Nf3!!"), san::parse(start, "Nf3"));
+}
+
+TEST(SanParse, CastlingMayBeWrittenWithZeroes)
+{
+    const Position position = mustParse("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1");
+    EXPECT_EQ(san::parse(position, "0-0"), san::parse(position, "O-O"));
+    EXPECT_EQ(san::parse(position, "0-0-0"), san::parse(position, "O-O-O"));
+    EXPECT_NE(san::parse(position, "O-O"), san::parse(position, "O-O-O"));
+}
+
+TEST(SanParse, EnPassantMayCarryTheTraditionalSuffix)
+{
+    const Position position = mustParse("rnbqkbnr/pp1ppppp/8/8/2pP4/8/PPP1PPPP/RNBQKBNR b KQkq d3 0 3");
+    const auto plain = san::parse(position, "cxd3");
+    ASSERT_TRUE(plain.has_value());
+    EXPECT_EQ(plain->kind, MoveKind::EnPassant);
+    EXPECT_EQ(san::parse(position, "cxd3e.p."), plain);
+}
+
+TEST(SanParse, RejectsMovesThatAreNotLegalHere)
+{
+    const Position start = Position::starting();
+    EXPECT_FALSE(san::parse(start, "e5").has_value());
+    EXPECT_FALSE(san::parse(start, "O-O").has_value());
+    EXPECT_FALSE(san::parse(start, "Qh5xf7#").has_value());
+    EXPECT_FALSE(san::parse(start, "").has_value());
+    EXPECT_FALSE(san::parse(start, "not a move").has_value());
+}
+
+// A promotion must name its piece; "e8" alone does not identify a move.
+TEST(SanParse, PromotionNeedsItsPiece)
+{
+    const Position position = mustParse("8/4P3/8/8/8/8/8/K6k w - - 0 1");
+    EXPECT_FALSE(san::parse(position, "e8").has_value());
+    ASSERT_TRUE(san::parse(position, "e8=R").has_value());
+    EXPECT_EQ(san::parse(position, "e8=R")->promotion, PieceType::Rook);
+}
+
+} // namespace
+} // namespace chess


### PR DESCRIPTION
Second of six stacked PRs modernizing CINES.
**Based on `modernize/01-core-build-ci`** — merge that one first;
the diff shown here collapses to just this PR's commits once it lands.

| # | Branch | Contents |
|---|--------|----------|
| 1 | `modernize/01-core-build-ci` | CMake build, core value types, FEN, CI |
| **2** | `modernize/02-rules-perft` | **Full FIDE rules, SAN/PGN/Game, perft** |
| 3 | `modernize/03-qt-app` | Qt 6 Widgets front end; legacy files deleted |
| 4 | `modernize/04-board-ux` | Themes, move affordances, animation |
| 5 | `modernize/05-side-panel` | Move list, captured tray, menus |
| 6 | `modernize/06-release` | AppImage, Windows zip, macOS DMG, Homebrew tap |

## Why

The 2012 game had no check detection, no castling, no en passant and no promotion,
and let a player move into check.
`validation::check()` returned 0 unconditionally, so no game ever ended.
This replaces all of it.

## Move generation is table-driven

A `constexpr` table gives each piece its directions and whether it slides along them,
so rook, bishop and queen share one ray walker
and knight and king share one hop walker.
The 668-line `validation.cpp`, which wrote the same ray walk out sixteen times,
becomes about eighty lines that can only be wrong in one place.

Generation is pseudo-legal first,
then filtered by playing each move and asking whether the mover's own king is attacked.
That is slower than tracking pins,
and it is right in the case pin-tracking gets wrong:
en passant, where two pawns leave the fifth rank at once
and can expose the king to a rook that was doubly blocked a moment earlier.
There is a test for exactly that position.

Attack detection works outwards from the square rather than iterating every enemy piece —
two lookups for pawns, eight for knights, one walk per ray.
It is the innermost operation in perft, so the shape matters.

## Perft is the acceptance test

All six standard Chess Programming Wiki positions match the published node counts **exactly**.

| Position | Depths in CI | Also run and passing |
|---|---|---|
| Start | 1–5 (4,865,609) | 6 — **119,060,324** |
| Kiwipete | 1–4 (4,085,603) | 5 — **193,690,690** |
| Position 3 | 1–5 (674,624) | 6 — 11,030,083 |
| Position 4 | 1–4 (422,333) | 5 — 15,833,292 |
| Position 5 | 1–4 (2,103,487) | — |
| Position 6 | 1–4 (3,894,594) | — |

The deeper levels sit behind `-DCINES_SLOW_TESTS=ON` to keep CI quick;
they have been run locally and pass.

Exact counts are the point.
A single mishandled castling or en passant case shows up here as a wrong number,
rather than as a bug found during a game years from now.

## Also added

| Type | Owns |
|---|---|
| `Rules` | check, checkmate, stalemate, insufficient material, fifty-move |
| `San` | move notation with disambiguation and check/mate suffixes, and a reader |
| `Game` | move history, undo, redo, jump-to-ply, threefold repetition |
| `Pgn` | the whole game as text, with `SetUp` and `FEN` for a custom start |

The SAN reader works by spelling every legal move and comparing,
so anything `toSan` can write, `parse` can read,
and no separate grammar can drift out of step with it.

Threefold repetition normalises away an en passant square that no pawn can actually capture onto.
FEN records that square unconditionally, as most tools do,
so without this two genuinely identical positions would compare unequal and the draw would be missed.

## Review notes

**The last commit is worth reading.**
Address sanitizer, on its first run against these rules, found this in `Game::play`:

```cpp
const Move* legal = legalMoves().find(move.from, move.to, move.promotion);
```

`legalMoves()` returns a `MoveList` **by value**,
so `find` handed back a pointer into a temporary that died at the semicolon.
Every later use read freed stack.

All 178 tests passed in both the debug and the optimised build,
because nothing had overwritten that stack yet.
Only the sanitizer caught it.

`find` now returns `std::optional<Move>`.
A `Move` is four bytes,
and calling `find` on a temporary list is the natural way to write it,
so returning a pointer was a trap laid for whoever wires up the board in PR 3.
Returning a value removes the trap rather than documenting it.
There is a regression test that calls `find` directly on a temporary.

**Deviation from plan, worth flagging:**
threefold repetition uses direct position comparison rather than a Zobrist hash.
The history is at most a few hundred positions, so the linear scan is free —
and unlike a hash it cannot collide.

## Verification

```
cmake --preset dev && cmake --build --preset dev && ctest --preset dev
```

- 179 tests pass.
- All 179 pass under address and undefined-behaviour sanitizers.
- Builds warning-free under `-Werror`; `clang-format` and `clang-tidy` clean.
- Deep perft run separately: `cmake --preset dev -DCINES_SLOW_TESTS=ON`.
